### PR TITLE
exp/minimap: Merge experimental minimap branch.

### DIFF
--- a/Assets/BML/ScriptableObjectCore/Scripts/Variables/SafeValueReferences/SafeTransformValueReference.cs
+++ b/Assets/BML/ScriptableObjectCore/Scripts/Variables/SafeValueReferences/SafeTransformValueReference.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections;
+using System.Data.SqlTypes;
+using System.Linq;
+using BML.ScriptableObjectCore.Scripts.CustomAttributes;
+using BML.ScriptableObjectCore.Scripts.SceneReferences;
+using BML.ScriptableObjectCore.Scripts.Variables;
+using Mono.CSharp;
+using Sirenix.OdinInspector;
+using UnityEditor;
+using UnityEngine;
+
+namespace BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences
+{
+    [InlineProperty]
+    [SynchronizedHeader]
+    [HideReferenceObjectPicker]
+    [Serializable]
+    public class SafeTransformValueReference
+    {
+        #region Inspector
+
+        public String Tooltip => this.Description;
+
+        public enum TransformReferenceTypes {
+            Transform = 0,
+            TransformSceneReference = 1,
+            GameObjectSceneReference = 2,
+        }
+        
+        [VerticalGroup("Top")]
+        [HorizontalGroup("Top/Split", LabelWidth = 0.001f)]
+        [HorizontalGroup("Top/Split/Left", LabelWidth = .01f)]
+        [BoxGroup("Top/Split/Left/Left", ShowLabel = false)]
+        [PropertyTooltip("$Tooltip")]
+        // [LabelText("T")] [LabelWidth(10f)]
+        [HideLabel]
+        [SerializeField]
+        protected TransformReferenceTypes ReferenceTypeSelector;
+        
+        #region Reference values
+
+        private bool _showTransform => ReferenceTypeSelector == TransformReferenceTypes.Transform;
+        [BoxGroup("Top/Split/Right", ShowLabel = false)]
+        [HideLabel]
+        [ShowIf("@_showTransform")]
+        [InlineEditor()]
+        [SerializeField]
+        protected Transform ReferenceValue_Transform;
+        
+        
+        private bool _showTransformSceneReference => ReferenceTypeSelector == TransformReferenceTypes.TransformSceneReference;
+        [BoxGroup("Top/Split/Right", ShowLabel = false)]
+        [HideLabel]
+        [ShowIf("@_showTransformSceneReference")]
+        [InlineEditor()]
+        [SerializeField]
+        protected TransformSceneReference ReferenceValue_TransformSceneReference;
+
+        
+        private bool _showGameObjectSceneReference => ReferenceTypeSelector == TransformReferenceTypes.GameObjectSceneReference;
+        [BoxGroup("Top/Split/Right", ShowLabel = false)]
+        [HideLabel]
+        [ShowIf("@_showGameObjectSceneReference")]
+        [InlineEditor()]
+        [SerializeField]
+        protected GameObjectSceneReference ReferenceValue_GameObjectSceneReference;
+
+        
+        
+        #endregion
+
+        
+        // protected bool InstanceNotConstant => (!UseConstant && EnableInstanceOptions);
+        
+        #endregion
+        
+        #region Interface
+
+        public Transform Value
+        {
+            get
+            {
+                switch (ReferenceTypeSelector)
+                {
+                    case TransformReferenceTypes.Transform:
+                        return ReferenceValue_Transform;
+                    case TransformReferenceTypes.TransformSceneReference:
+                        return ReferenceValue_TransformSceneReference?.Value;
+                    case TransformReferenceTypes.GameObjectSceneReference:
+                        return ReferenceValue_GameObjectSceneReference?.Value.transform;
+                    default:
+                        Debug.LogError($"Trying to access Transform but none set in inspector!");
+                        return default(Transform);
+                }
+            }
+            set
+            {
+                switch (ReferenceTypeSelector)
+                {
+                    case TransformReferenceTypes.Transform:
+                        if (ReferenceValue_Transform != null)
+                            ReferenceValue_Transform = value;
+                        break;
+                    case TransformReferenceTypes.TransformSceneReference:
+                        if (ReferenceValue_TransformSceneReference != null)
+                            ReferenceValue_TransformSceneReference.Value = value;
+                        break;
+                    case TransformReferenceTypes.GameObjectSceneReference:
+                        Debug.LogError($"Cannot set set Transform for type GameObjectSceneReference!");
+                        break;
+                    default:
+                        Debug.LogError($"Trying to access Transform but none set in inspector!");
+                        break;
+                }
+            }
+        }
+
+        public String Name
+        {
+            get
+            {
+                switch (ReferenceTypeSelector)
+                {
+                    case TransformReferenceTypes.Transform:
+                        return ReferenceValue_Transform?.name;
+                    case TransformReferenceTypes.TransformSceneReference:
+                        return ReferenceValue_TransformSceneReference?.name;
+                    case TransformReferenceTypes.GameObjectSceneReference:
+                        return ReferenceValue_GameObjectSceneReference?.name;
+                }
+                return "<Missing Transform>";
+            }
+        }
+        
+        public String Description
+        {
+            get
+            {
+                switch (ReferenceTypeSelector)
+                {
+                    case TransformReferenceTypes.Transform:
+                        return ReferenceValue_Transform?.name;
+                    case TransformReferenceTypes.TransformSceneReference:
+                        return ReferenceValue_TransformSceneReference?.Description;
+                    case TransformReferenceTypes.GameObjectSceneReference:
+                        return ReferenceValue_GameObjectSceneReference?.Description;
+                }
+                return "<Missing Transform>";
+            }
+        }
+
+        // public void Subscribe(OnUpdate callback)
+        // {
+        //     switch (ReferenceTypeSelector)
+        //     {
+        //         case TransformReferenceTypes.Transform:
+        //             // ReferenceValue_Transform?.Subscribe(callback);
+        //             break;
+        //         case TransformReferenceTypes.TransformSceneReference:
+        //             // ReferenceValue_TransformSceneReference?.Subscribe(callback);
+        //             break;
+        //     }
+        // }
+        //
+        // public void Unsubscribe(OnUpdate callback)
+        // {
+        //     switch (ReferenceTypeSelector)
+        //     {
+        //         case TransformReferenceTypes.Transform:
+        //             // ReferenceValue_Transform?.Unsubscribe(callback);
+        //             break;
+        //         case TransformReferenceTypes.TransformSceneReference:
+        //             // ReferenceValue_TransformSceneReference?.Unsubscribe(callback);
+        //             break;
+        //     }
+        // }
+
+        #endregion
+    }
+}

--- a/Assets/BML/ScriptableObjectCore/Scripts/Variables/SafeValueReferences/SafeTransformValueReference.cs.meta
+++ b/Assets/BML/ScriptableObjectCore/Scripts/Variables/SafeValueReferences/SafeTransformValueReference.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0bdf0999754049a7926b5e120017e15d
+timeCreated: 1678163795

--- a/Assets/Entities/CaveGen/MiniMap.meta
+++ b/Assets/Entities/CaveGen/MiniMap.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe259dc1d07ea1a4c9316d6d63a588c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/CaveGen/MiniMap/MinimapContainer_TransformSceneReference.asset
+++ b/Assets/Entities/CaveGen/MiniMap/MinimapContainer_TransformSceneReference.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ee3f20523483ae140947ceba712c88aa, type: 3}
+  m_Name: MinimapContainer_TransformSceneReference
+  m_EditorClassIdentifier: 
+  Description: 
+  reference: {fileID: 0}

--- a/Assets/Entities/CaveGen/MiniMap/MinimapContainer_TransformSceneReference.asset.meta
+++ b/Assets/Entities/CaveGen/MiniMap/MinimapContainer_TransformSceneReference.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38c36189f686df949aa9c03df030f995
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab
@@ -47,6 +47,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   CaveGenerator: {fileID: 0}
+  MinimapController: {fileID: 0}
   OuterRenderer: {fileID: 7783465044350624173}
 --- !u!114 &7783465044350624173
 MonoBehaviour:

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7783465044350624173}
   - component: {fileID: 8271577214393143892}
   - component: {fileID: 1419900810768725649}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Minimap_CaveNode
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -30,7 +30,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 644061555193005920}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -48,7 +49,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CaveGenerator: {fileID: 0}
   MinimapController: {fileID: 0}
-  OuterRenderer: {fileID: 7783465044350624173}
+  UndiscoveredRenderer: {fileID: 910780572922291156}
+  DiscoveredRenderer: {fileID: 7783465044350624173}
 --- !u!114 &7783465044350624173
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -62,9 +64,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   meshOutOfDate: 1
-  blendMode: 0
+  blendMode: 1
   scaleMode: 0
-  color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  color: {r: 0.5, g: 0.5, b: 0.5, a: 0.5019608}
   zTest: 4
   zOffsetFactor: 0
   zOffsetUnits: 0
@@ -98,7 +100,113 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: f6ee19c96066bc444a5cc1a12233dfe6, type: 2}
+  - {fileID: 2100000, guid: 628f131798f2fca4fbfa6881a9f300f3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8885806344568042145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 644061555193005920}
+  - component: {fileID: 910780572922291156}
+  - component: {fileID: 896565248467997566}
+  - component: {fileID: 8153549557704291692}
+  m_Layer: 8
+  m_Name: Torus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &644061555193005920
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8885806344568042145}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7841689349810623231}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+--- !u!114 &910780572922291156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8885806344568042145}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1046b222c67bd446b423ebdeb4f178b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  meshOutOfDate: 1
+  blendMode: 1
+  scaleMode: 0
+  color: {r: 0.5019608, g: 0.5019608, b: 0.5019608, a: 0.5019608}
+  zTest: 4
+  zOffsetFactor: 0
+  zOffsetUnits: 0
+  generatedComponentHideFlags: 2
+  radius: 2
+  thickness: 1.5
+  thicknessSpace: 0
+  radiusSpace: 0
+--- !u!33 &896565248467997566
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8885806344568042145}
+  m_Mesh: {fileID: 4300004, guid: 93e008a3a312f6041bb52f2c0413bc68, type: 3}
+--- !u!23 &8153549557704291692
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8885806344568042145}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 145d4ed0186cfe847aebcf598f445ff4, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab
@@ -1,0 +1,121 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5438425376239770469
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7841689349810623231}
+  - component: {fileID: 2616182956180802966}
+  - component: {fileID: 7783465044350624173}
+  - component: {fileID: 8271577214393143892}
+  - component: {fileID: 1419900810768725649}
+  m_Layer: 0
+  m_Name: Minimap_CaveNode
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7841689349810623231
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5438425376239770469}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2616182956180802966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5438425376239770469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 51319c8964284f8386545325a03e73c6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CaveGenerator: {fileID: 0}
+  OuterRenderer: {fileID: 7783465044350624173}
+--- !u!114 &7783465044350624173
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5438425376239770469}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0227a202d6d1e944888db8f30673549b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  meshOutOfDate: 1
+  blendMode: 0
+  scaleMode: 0
+  color: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  zTest: 4
+  zOffsetFactor: 0
+  zOffsetUnits: 0
+  generatedComponentHideFlags: 2
+  radius: 3
+  radiusSpace: 0
+--- !u!33 &8271577214393143892
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5438425376239770469}
+  m_Mesh: {fileID: 4300002, guid: 93e008a3a312f6041bb52f2c0413bc68, type: 3}
+--- !u!23 &1419900810768725649
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5438425376239770469}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: f6ee19c96066bc444a5cc1a12233dfe6, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab.meta
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNode.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5a35d0da4d4f67d4fbffac970af1b047
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNodeConnection.prefab
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNodeConnection.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 7167432180987166975}
   - component: {fileID: 7392556096886451848}
   - component: {fileID: 1447459946804770082}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Minimap_CaveNodeConnection
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -47,6 +47,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   CaveGenerator: {fileID: 0}
+  MinimapController: {fileID: 0}
   Line: {fileID: 7167432180987166975}
 --- !u!114 &7167432180987166975
 MonoBehaviour:
@@ -77,12 +78,12 @@ MonoBehaviour:
   thicknessSpace: 0
   endCaps: 2
   matchDashSpacingToSize: 1
-  dashed: 0
+  dashed: 1
   dashStyle:
     type: 0
-    space: -1
+    space: 0
     snap: 0
-    size: 4
+    size: 2
     offset: 0
     spacing: 4
     shapeModifier: 1

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNodeConnection.prefab
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNodeConnection.prefab
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6485907687262205468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8803750372672259902}
+  - component: {fileID: 1733517122604886120}
+  - component: {fileID: 7167432180987166975}
+  - component: {fileID: 7392556096886451848}
+  - component: {fileID: 1447459946804770082}
+  m_Layer: 0
+  m_Name: Minimap_CaveNodeConnection
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8803750372672259902
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6485907687262205468}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1733517122604886120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6485907687262205468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc4e7340e2f74bc99df97fe997c5bce3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CaveGenerator: {fileID: 0}
+  Line: {fileID: 7167432180987166975}
+--- !u!114 &7167432180987166975
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6485907687262205468}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5ad38a8f0c6def84899724d5320b316a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  meshOutOfDate: 1
+  blendMode: 1
+  scaleMode: 0
+  color: {r: 1, g: 1, b: 1, a: 1}
+  zTest: 4
+  zOffsetFactor: 0
+  zOffsetUnits: 0
+  generatedComponentHideFlags: 2
+  geometry: 1
+  colorMode: 0
+  colorEnd: {r: 1, g: 1, b: 1, a: 1}
+  start: {x: 0, y: 0, z: 0}
+  end: {x: 1, y: 0, z: 0}
+  thickness: 2
+  thicknessSpace: 0
+  endCaps: 2
+  matchDashSpacingToSize: 1
+  dashed: 0
+  dashStyle:
+    type: 0
+    space: -1
+    snap: 0
+    size: 4
+    offset: 0
+    spacing: 4
+    shapeModifier: 1
+--- !u!33 &7392556096886451848
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6485907687262205468}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1447459946804770082
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6485907687262205468}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d8dcf53039a8e5f468fb44f7e1a08f76, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNodeConnection.prefab.meta
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_CaveNodeConnection.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4263009ba6c7950488c77082a2bc7b15
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_ZoomLevel.asset
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_ZoomLevel.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 32
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f5be68029433444586fe71b7a1236e9, type: 3}
+  m_Name: Minimap_ZoomLevel
+  m_EditorClassIdentifier: 
+  EnableDebugOnUpdate: 0
+  Description: 
+  defaultValue: 0.5
+  runtimeValue: 0.5
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []

--- a/Assets/Entities/CaveGen/MiniMap/Minimap_ZoomLevel.asset.meta
+++ b/Assets/Entities/CaveGen/MiniMap/Minimap_ZoomLevel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ae640b574cc1b640a31642f1a91cd82
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
+++ b/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
@@ -16,3 +16,12 @@ MonoBehaviour:
   PrefabCaveNodeConnection: {fileID: 6485907687262205468, guid: 4263009ba6c7950488c77082a2bc7b15, type: 3}
   DefaultColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
   VisitedColor: {r: 0.07105985, g: 0.6509434, b: 0.6086957, a: 1}
+  CulledColor: {r: 1, g: 0, b: 0, a: 1}
+  ZoomLevel:
+    ReferenceTypeSelector: 1
+    ConstantValue: 0
+    ReferenceValue_FloatVariable: {fileID: 11400000, guid: 1ae640b574cc1b640a31642f1a91cd82, type: 2}
+    ReferenceValue_IntVariable: {fileID: 0}
+    ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+  RestrictMapRadius: 1
+  MapPlayerRadius: 30

--- a/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
+++ b/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 52eeccc75c404f2f95692325b05cffb8, type: 3}
+  m_Name: caveMinimapParameters
+  m_EditorClassIdentifier: 
+  PrefabCaveNode: {fileID: 5438425376239770469, guid: 5a35d0da4d4f67d4fbffac970af1b047, type: 3}
+  PrefabCaveNodeConnection: {fileID: 6485907687262205468, guid: 4263009ba6c7950488c77082a2bc7b15, type: 3}
+  DefaultColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
+  VisitedColor: {r: 0.07105985, g: 0.6509434, b: 0.6086957, a: 1}

--- a/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
+++ b/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
@@ -14,9 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   PrefabCaveNode: {fileID: 5438425376239770469, guid: 5a35d0da4d4f67d4fbffac970af1b047, type: 3}
   PrefabCaveNodeConnection: {fileID: 6485907687262205468, guid: 4263009ba6c7950488c77082a2bc7b15, type: 3}
-  DefaultColor: {r: 0.7169812, g: 0.7169812, b: 0.7169812, a: 1}
-  VisitedColor: {r: 0.07105985, g: 0.6509434, b: 0.6086957, a: 1}
-  CulledColor: {r: 1, g: 0, b: 0, a: 1}
+  CulledColor: {r: 0.1, g: 0.1, b: 0.1, a: 0}
+  VisibleColor: {r: 0.3679245, g: 0.3679245, b: 0.3679245, a: 1}
+  VisitedColor: {r: 0.754717, g: 0.754717, b: 0.754717, a: 1}
+  OccupiedColor: {r: 0.8396226, g: 0.8303987, b: 0.36889085, a: 1}
   ZoomLevel:
     ReferenceTypeSelector: 1
     ConstantValue: 0

--- a/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
+++ b/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   PrefabCaveNode: {fileID: 5438425376239770469, guid: 5a35d0da4d4f67d4fbffac970af1b047, type: 3}
   PrefabCaveNodeConnection: {fileID: 6485907687262205468, guid: 4263009ba6c7950488c77082a2bc7b15, type: 3}
-  CulledColor: {r: 0.1, g: 0.1, b: 0.1, a: 0}
+  CulledColor: {r: 1, g: 0, b: 0, a: 0}
   VisibleColor: {r: 0.3679245, g: 0.3679245, b: 0.3679245, a: 1}
   VisitedColor: {r: 0.3679245, g: 0.3679245, b: 0.3679245, a: 1}
   OccupiedColor: {r: 0.8396226, g: 0.8303987, b: 0.36889085, a: 1}
@@ -32,5 +32,11 @@ MonoBehaviour:
     ReferenceValue_FloatVariable: {fileID: 11400000, guid: 1ae640b574cc1b640a31642f1a91cd82, type: 2}
     ReferenceValue_IntVariable: {fileID: 0}
     ReferenceValue_EvaluateCurveVariable: {fileID: 0}
-  RestrictMapRadius: 1
-  MapPlayerRadius: 30
+  OpenMapOverlay:
+    UseConstant: 0
+    EnableInstanceOptions: 0
+    InstanceName: '{I} '
+    InstancePath: IntermediateProperties
+    ConstantValue: 0
+    Variable: {fileID: 11400000, guid: 78096da5c2f101d45a1fe35e8477cd52, type: 2}
+  MapPlayerRadius: 20

--- a/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
+++ b/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset
@@ -16,8 +16,16 @@ MonoBehaviour:
   PrefabCaveNodeConnection: {fileID: 6485907687262205468, guid: 4263009ba6c7950488c77082a2bc7b15, type: 3}
   CulledColor: {r: 0.1, g: 0.1, b: 0.1, a: 0}
   VisibleColor: {r: 0.3679245, g: 0.3679245, b: 0.3679245, a: 1}
-  VisitedColor: {r: 0.754717, g: 0.754717, b: 0.754717, a: 1}
+  VisitedColor: {r: 0.3679245, g: 0.3679245, b: 0.3679245, a: 1}
   OccupiedColor: {r: 0.8396226, g: 0.8303987, b: 0.36889085, a: 1}
+  LineConnectionEndOffset: 3.1
+  RelativeScale_Unassigned: 0.4
+  RelativeScale_Small: 0.7
+  RelativeScale_Medium: 1.4
+  RelativeScale_Large: 2
+  Color_StartRoom: {r: 0.44847605, g: 0.84300005, b: 0.44847605, a: 1}
+  Color_EndRoom: {r: 0.8, g: 0.22800003, b: 0.22800003, a: 1}
+  Color_MerchantRoom: {r: 0.5869939, g: 0.1963078, b: 0.754717, a: 1}
   ZoomLevel:
     ReferenceTypeSelector: 1
     ConstantValue: 0

--- a/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset.meta
+++ b/Assets/Entities/CaveGen/MiniMap/caveMinimapParameters.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb356ad72f43032459506de3aafa682e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Game/MenuState/Container_GameMenuState_InteractableOverlay.asset
+++ b/Assets/Entities/Game/MenuState/Container_GameMenuState_InteractableOverlay.asset
@@ -18,6 +18,7 @@ MonoBehaviour:
   TriggerVariables: []
   BoolVariables:
   - {fileID: 11400000, guid: 2c6a9ec7ffcec724b83f7abc212de507, type: 2}
+  - {fileID: 11400000, guid: 78096da5c2f101d45a1fe35e8477cd52, type: 2}
   IntVariables: []
   FloatVariables: []
   Vector2Variables: []

--- a/Assets/Entities/Game/MenuState/Container_GameMenuState_NonBlocking.asset
+++ b/Assets/Entities/Game/MenuState/Container_GameMenuState_NonBlocking.asset
@@ -20,6 +20,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 2d4bb91fdd2f4474782d5fc27857d121, type: 2}
   - {fileID: 11400000, guid: 2c6a9ec7ffcec724b83f7abc212de507, type: 2}
   - {fileID: 11400000, guid: b097147d192343940aca02f32a439f21, type: 2}
+  - {fileID: 11400000, guid: 78096da5c2f101d45a1fe35e8477cd52, type: 2}
   IntVariables: []
   FloatVariables: []
   Vector2Variables: []

--- a/Assets/Entities/Game/MenuState/Game_MenuIsOpen_ANY_InteractableOverlay.asset
+++ b/Assets/Entities/Game/MenuState/Game_MenuIsOpen_ANY_InteractableOverlay.asset
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 32
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 21f99ffcb30e8c149bd12c04c3f45d2a, type: 3}
+  m_Name: Game_MenuIsOpen_ANY_InteractableOverlay
+  m_EditorClassIdentifier: 
+  EnableDebugOnUpdate: 0
+  Description: 'TREAT AS READ-ONLY
+
+
+    This is assigned by the PlayerInputProcessor
+
+'
+  defaultValue: 0
+  runtimeValue: 0
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []

--- a/Assets/Entities/Game/MenuState/Game_MenuIsOpen_ANY_InteractableOverlay.asset.meta
+++ b/Assets/Entities/Game/MenuState/Game_MenuIsOpen_ANY_InteractableOverlay.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e56a6a71f1ce4f948a45e2c6625e1798
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Game/MenuState/Game_MenuIsOpen_Minimap.asset
+++ b/Assets/Entities/Game/MenuState/Game_MenuIsOpen_Minimap.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 32
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 21f99ffcb30e8c149bd12c04c3f45d2a, type: 3}
+  m_Name: Game_MenuIsOpen_Minimap
+  m_EditorClassIdentifier: 
+  EnableDebugOnUpdate: 0
+  Description: 'When false, the only the nearby area will be displayed on the HUD.
+
+    When
+    true, it will "open" to take up the middle of the screen, giving player better
+    controls for viewing the entire map.'
+  defaultValue: 0
+  runtimeValue: 0
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []

--- a/Assets/Entities/Game/MenuState/Game_MenuIsOpen_Minimap.asset.meta
+++ b/Assets/Entities/Game/MenuState/Game_MenuIsOpen_Minimap.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78096da5c2f101d45a1fe35e8477cd52
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -13362,7 +13362,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3458691578313647654}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -13708,7 +13708,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &7073329726129986620
 Transform:
   m_ObjectHideFlags: 0
@@ -29042,7 +29042,7 @@ MeshRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8358215118179947233}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -13556,7 +13556,7 @@ MonoBehaviour:
   blendMode: 1
   scaleMode: 0
   color: {r: 1, g: 1, b: 1, a: 1}
-  zTest: 4
+  zTest: 8
   zOffsetFactor: 0
   zOffsetUnits: 0
   generatedComponentHideFlags: 2
@@ -13589,7 +13589,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 628f131798f2fca4fbfa6881a9f300f3, type: 2}
+  - {fileID: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -29632,7 +29632,7 @@ MonoBehaviour:
   blendMode: 1
   scaleMode: 0
   color: {r: 0.8768357, g: 0.9150943, b: 0.37615073, a: 1}
-  zTest: 4
+  zTest: 8
   zOffsetFactor: 0
   zOffsetUnits: 0
   generatedComponentHideFlags: 2
@@ -29667,7 +29667,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 4d60ecf9a3a734347933d3c049e7e21b, type: 2}
+  - {fileID: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -8065,7 +8065,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 162339389660353893}
+  m_Father: {fileID: 4263997310979020706}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &196977129928123002
@@ -8093,7 +8093,7 @@ MonoBehaviour:
     ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122, type: 2}
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _translationTarget: {fileID: 6780521088754864702}
-  _scalingTarget: {fileID: 162339389660353893}
+  _scalingTarget: {fileID: 4263997310979020706}
   _cullOutside: {fileID: 8362569841916225692}
   _zoomBaseline: 0.006
 --- !u!1 &1797728375059188022
@@ -9032,6 +9032,65 @@ LineRenderer:
     generateLightingData: 0
   m_UseWorldSpace: 0
   m_Loop: 0
+--- !u!1 &2302739639425751954
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4263997310979020706}
+  - component: {fileID: 439697722256897288}
+  m_Layer: 7
+  m_Name: Minimap (offset replica)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4263997310979020706
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2302739639425751954}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.006, y: 0.006, z: 0.006}
+  m_Children:
+  - {fileID: 6780521088754864702}
+  m_Father: {fileID: 4360969640052789754}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &439697722256897288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2302739639425751954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83a28b539cad4ce0a0107cafc58c739c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _target:
+    ReferenceTypeSelector: 0
+    ReferenceValue_Transform: {fileID: 162339389660353893}
+    ReferenceValue_TransformSceneReference: {fileID: 0}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  _transform:
+    ReferenceTypeSelector: 0
+    ReferenceValue_Transform: {fileID: 4263997310979020706}
+    ReferenceValue_TransformSceneReference: {fileID: 0}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  _readLocalRotation: 1
+  _setLocalRotation: 1
+  _remapAngles: 1
+  _remapAnglesMin: {x: 0, y: 0, z: 0}
+  _remapAnglesMax: {x: 10, y: 360, z: 10}
 --- !u!1 &2331793945456284132
 GameObject:
   m_ObjectHideFlags: 0
@@ -9114,6 +9173,37 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &2360800453983378263
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4360969640052789754}
+  m_Layer: 7
+  m_Name: Minimap (constant rotation offset)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4360969640052789754
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2360800453983378263}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4263997310979020706}
+  m_Father: {fileID: 1124496401759698450}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!1 &2432463934219413715
 GameObject:
   m_ObjectHideFlags: 0
@@ -15728,6 +15818,9 @@ MonoBehaviour:
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _readLocalRotation: 0
   _setLocalRotation: 0
+  _remapAngles: 0
+  _remapAnglesMin: {x: 0, y: 0, z: 0}
+  _remapAnglesMax: {x: 360, y: 360, z: 360}
 --- !u!1 &4292042580474181362
 GameObject:
   m_ObjectHideFlags: 0
@@ -23178,8 +23271,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.006, y: 0.006, z: 0.006}
-  m_Children:
-  - {fileID: 6780521088754864702}
+  m_Children: []
   m_Father: {fileID: 1124496401759698450}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -23244,7 +23336,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1124496401759698450}
   m_Layer: 7
-  m_Name: Minimap
+  m_Name: Minimap (main)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -23257,13 +23349,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6266807033874931565}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: 0.07132119, z: 0.5}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.07132149, z: 0.5000011}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 162339389660353893}
   - {fileID: 8559044050560204755}
   - {fileID: 4944558589552590849}
+  - {fileID: 4360969640052789754}
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -5553,7 +5553,7 @@ Transform:
   m_Children:
   - {fileID: 2794262310649021554}
   m_Father: {fileID: 7265003986444444711}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &6637335878769414553
 BoxCollider:
@@ -7993,6 +7993,36 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &1560123334007057798
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6780521088754864702}
+  m_Layer: 7
+  m_Name: Minimap Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6780521088754864702
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560123334007057798}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.0012516975, y: -0.00017881393, z: 0.0006854534}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 162339389660353893}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1797728375059188022
 GameObject:
   m_ObjectHideFlags: 0
@@ -9041,7 +9071,7 @@ Transform:
   m_Children:
   - {fileID: 3561747769528798360}
   m_Father: {fileID: 7265003986444444711}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8885636104298291231
 MonoBehaviour:
@@ -10576,7 +10606,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4471686e47874b48b8aeec3888432212, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _target: {fileID: 11400000, guid: 3c3492e91b965ee4d82d2c05d11f03e1, type: 2}
+  _targetMode: 0
+  _target:
+    ReferenceTypeSelector: 1
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 3c3492e91b965ee4d82d2c05d11f03e1, type: 2}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _maxAngularVelocity: 20
   _footstepNoiseInfluence: 8
   _footstepNoiseForceMode: 2
@@ -12122,7 +12157,7 @@ Transform:
   - {fileID: 1058941167527773644}
   - {fileID: 4819841808157791852}
   m_Father: {fileID: 7265003986444444711}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 15}
 --- !u!1 &3458691578313647654
 GameObject:
@@ -16170,7 +16205,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4471686e47874b48b8aeec3888432212, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _target: {fileID: 11400000, guid: 3c3492e91b965ee4d82d2c05d11f03e1, type: 2}
+  _targetMode: 0
+  _target:
+    ReferenceTypeSelector: 1
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 3c3492e91b965ee4d82d2c05d11f03e1, type: 2}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _maxAngularVelocity: 20
   _footstepNoiseInfluence: 0
   _footstepNoiseForceMode: 2
@@ -22981,6 +23021,121 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1 &6250237178606343246
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162339389660353893}
+  - component: {fileID: 3003641197398480286}
+  - component: {fileID: 5520238887478614414}
+  m_Layer: 7
+  m_Name: Minimap Pivot (PID)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &162339389660353893
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6250237178606343246}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.0123, y: 0.0715, z: 0.2539}
+  m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
+  m_Children:
+  - {fileID: 6780521088754864702}
+  m_Father: {fileID: 1124496401759698450}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3003641197398480286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6250237178606343246}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4471686e47874b48b8aeec3888432212, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetMode: 1
+  _target:
+    ReferenceTypeSelector: 2
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 0}
+    ReferenceValue_GameObjectSceneReference: {fileID: 11400000, guid: 70c332354ecbb9c46bf117bd4c575bab, type: 2}
+  _maxAngularVelocity: 20
+  _footstepNoiseInfluence: 0
+  _footstepNoiseForceMode: 2
+  _rotationNoiseInfluence: 0
+  _rotationNoiseScale: {x: 1, y: 1, z: 1}
+  _rotationNoiseForceMode: 5
+  _rotationNoiseAngularDifferenceThreshold: 50
+  _useXValuesForAllAxes: 1
+  _xAxisP: 0.1
+  _xAxisI: 0
+  _xAxisD: 0.05
+  _yAxisP: 0
+  _yAxisI: 0
+  _yAxisD: 0
+  _zAxisP: 0
+  _zAxisI: 0
+  _zAxisD: 0
+--- !u!54 &5520238887478614414
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6250237178606343246}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 14
+  m_CollisionDetection: 0
+--- !u!1 &6266807033874931565
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1124496401759698450}
+  m_Layer: 7
+  m_Name: Minimap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1124496401759698450
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6266807033874931565}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 162339389660353893}
+  m_Father: {fileID: 7265003986444444711}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6281234742112583323
 GameObject:
   m_ObjectHideFlags: 0
@@ -24787,6 +24942,7 @@ Transform:
   - {fileID: 2711247591783983908}
   - {fileID: 4936108711428930162}
   - {fileID: 7073329726129986620}
+  - {fileID: 1124496401759698450}
   - {fileID: 281772354757565551}
   - {fileID: 7534361477877803264}
   - {fileID: 2948586884496874650}
@@ -25118,7 +25274,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7265003986444444711}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!135 &7240857008582618269
 SphereCollider:
@@ -27899,11 +28055,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
---- !u!4 &981458945698494185 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6347296434736609577, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
-  m_PrefabInstance: {fileID: 6163448547068399552}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6763227702262468176 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 599884813771948432, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
@@ -27915,6 +28066,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &981458945698494185 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6347296434736609577, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
+  m_PrefabInstance: {fileID: 6163448547068399552}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6543468985606383630
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27972,14 +28128,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
---- !u!4 &3561747769528798360 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7755986796828648598, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
-  m_PrefabInstance: {fileID: 6543468985606383630}
-  m_PrefabAsset: {fileID: 0}
 --- !u!198 &3728946144052914370 stripped
 ParticleSystem:
   m_CorrespondingSourceObject: {fileID: 7597839329562230988, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
+  m_PrefabInstance: {fileID: 6543468985606383630}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3561747769528798360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7755986796828648598, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
   m_PrefabInstance: {fileID: 6543468985606383630}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6947250416337299594

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -8002,7 +8002,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6780521088754864702}
-  m_Layer: 7
+  - component: {fileID: 196977129928123002}
+  m_Layer: 8
   m_Name: Minimap Container
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8017,12 +8018,43 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1560123334007057798}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.0012516975, y: -0.00017881393, z: 0.0006854534}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 162339389660353893}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &196977129928123002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560123334007057798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b16b260343dd417aabd2e467dbfa0901, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _doCenterOnPlayer: 1
+  _levelRoot:
+    ReferenceTypeSelector: 2
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 0}
+    ReferenceValue_GameObjectSceneReference: {fileID: 11400000, guid: 70c332354ecbb9c46bf117bd4c575bab, type: 2}
+  _playerPosition:
+    ReferenceTypeSelector: 1
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122, type: 2}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  _zoomLevel:
+    ReferenceTypeSelector: 1
+    ConstantValue: 0
+    ReferenceValue_FloatVariable: {fileID: 11400000, guid: 1ae640b574cc1b640a31642f1a91cd82, type: 2}
+    ReferenceValue_IntVariable: {fileID: 0}
+    ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+  _translationTarget: {fileID: 6780521088754864702}
+  _scalingTarget: {fileID: 162339389660353893}
 --- !u!1 &1797728375059188022
 GameObject:
   m_ObjectHideFlags: 0
@@ -23047,8 +23079,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6250237178606343246}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.0123, y: 0.0715, z: 0.2539}
-  m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.006, y: 0.006, z: 0.006}
   m_Children:
   - {fileID: 6780521088754864702}
   m_Father: {fileID: 1124496401759698450}
@@ -23129,7 +23161,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6266807033874931565}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0, y: 0.07132119, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 162339389660353893}
@@ -28055,6 +28087,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
+--- !u!4 &981458945698494185 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6347296434736609577, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
+  m_PrefabInstance: {fileID: 6163448547068399552}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6763227702262468176 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 599884813771948432, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
@@ -28066,11 +28103,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &981458945698494185 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6347296434736609577, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
-  m_PrefabInstance: {fileID: 6163448547068399552}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6543468985606383630
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -10016,6 +10016,7 @@ MonoBehaviour:
   playerInput: {fileID: 2719825288227953964}
   _isUsingUi_Out_Any: {fileID: 11400000, guid: 61da9144b637d0f4695d0e6fcb4ab9a2, type: 2}
   _isUsingUi_Out_HidePlayerHUD: {fileID: 11400000, guid: 049dd567b65e81547a7ebd9532982c5b, type: 2}
+  _isUsingUi_Out_InteractableOverlay: {fileID: 11400000, guid: e56a6a71f1ce4f948a45e2c6625e1798, type: 2}
 --- !u!114 &6318842967923595271
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -11019,7 +11020,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   BoolVariables:
-  - {fileID: 11400000, guid: 2c6a9ec7ffcec724b83f7abc212de507, type: 2}
+  - {fileID: 11400000, guid: e56a6a71f1ce4f948a45e2c6625e1798, type: 2}
   FloatVariables: []
   IntVariables: []
   Vector2Variables: []
@@ -14241,7 +14242,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   BoolVariables:
-  - {fileID: 11400000, guid: 2c6a9ec7ffcec724b83f7abc212de507, type: 2}
+  - {fileID: 11400000, guid: e56a6a71f1ce4f948a45e2c6625e1798, type: 2}
   FloatVariables: []
   IntVariables: []
   Vector2Variables: []
@@ -15689,7 +15690,7 @@ MonoBehaviour:
         Owner: {fileID: 5867985048384857021}
         DebugActive: 0
         TargetTransform: {fileID: 5748581132110267339}
-        ForceOrigin: 1
+        ForceOrigin: 0
         Origin: {fileID: 7014641073367806673}
         Destination: {fileID: 3583071166274424228}
         UseLocalPosition: 1

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -55,7 +55,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.2
+  near clip plane: 0.01
   far clip plane: 500
   field of view: 40
   orthographic: 0
@@ -5523,50 +5523,6 @@ Transform:
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &603536171153513679
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4944558589552590849}
-  - component: {fileID: 8362569841916225692}
-  m_Layer: 0
-  m_Name: Cull Outside
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!4 &4944558589552590849
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 603536171153513679}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1124496401759698450}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!135 &8362569841916225692
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 603536171153513679}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.05
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &641693477969724353
 GameObject:
   m_ObjectHideFlags: 0
@@ -8092,9 +8048,64 @@ MonoBehaviour:
     ReferenceValue_Transform: {fileID: 0}
     ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122, type: 2}
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
-  _translationTarget: {fileID: 6780521088754864702}
+  _pivotTranslationTarget: {fileID: 6780521088754864702}
   _scalingTarget: {fileID: 4263997310979020706}
-  _cullOutside: {fileID: 8362569841916225692}
+  _cameraRotationCompensation: {fileID: 4812894782618110578}
+  _playerMarkerRotationCompensation: {fileID: 7766843860951723989}
+  _onOverlayOpen:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 3033368034392618734}
+        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+        m_MethodName: StopFeedbacks
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 5765002987134345664}
+        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+        m_MethodName: PlayFeedbacks
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  _onOverlayClose:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5765002987134345664}
+        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+        m_MethodName: StopFeedbacks
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3033368034392618734}
+        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+        m_MethodName: PlayFeedbacks
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   _zoomBaseline: 0.002
 --- !u!1 &1797728375059188022
 GameObject:
@@ -9089,6 +9100,8 @@ MonoBehaviour:
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _readLocalRotation: 1
   _setLocalRotation: 1
+  _clearLocalRotationOnDisable: 0
+  _maxDegreesDelta: 360
   _remapAngles: 0
   _remapAnglesOldMin: {x: 0, y: 0, z: 0}
   _remapAnglesOldMax: {x: 360, y: 360, z: 360}
@@ -9206,7 +9219,7 @@ Transform:
   m_Children:
   - {fileID: 4263997310979020706}
   m_Father: {fileID: 1124496401759698450}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!114 &4812894782618110578
 MonoBehaviour:
@@ -9232,6 +9245,8 @@ MonoBehaviour:
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _readLocalRotation: 1
   _setLocalRotation: 1
+  _clearLocalRotationOnDisable: 1
+  _maxDegreesDelta: 3
   _remapAngles: 1
   _remapAnglesOldMin: {x: 90, y: 0, z: 0}
   _remapAnglesOldMax: {x: -90, y: 360, z: 360}
@@ -9553,6 +9568,36 @@ MonoBehaviour:
         RolloffMode: 0
         MinDistance: 1
         MaxDistance: 500
+--- !u!1 &2561182409579900884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2047241205932775296}
+  m_Layer: 7
+  m_Name: Minimap (Overlay position)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2047241205932775296
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2561182409579900884}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.25000054}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2509723621614378134}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2601160886124357314
 GameObject:
   m_ObjectHideFlags: 0
@@ -9876,6 +9921,13 @@ MonoBehaviour:
     InstancePath: IntermediateProperties
     ConstantValue: 0
     Variable: {fileID: 11400000, guid: 3975cff0b522fb945a1344e66029a983, type: 2}
+  _isMinimapOpen:
+    UseConstant: 0
+    EnableInstanceOptions: 0
+    InstanceName: 
+    InstancePath: IntermediateProperties
+    ConstantValue: 0
+    Variable: {fileID: 11400000, guid: 78096da5c2f101d45a1fe35e8477cd52, type: 2}
   _isStoreOpen:
     UseConstant: 0
     EnableInstanceOptions: 0
@@ -12404,6 +12456,807 @@ Transform:
   m_Father: {fileID: 42333560796704333}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3346644239416305965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7117754610999773938}
+  - component: {fileID: 5765002987134345664}
+  m_Layer: 7
+  m_Name: OverlayOpenFeedbacks
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7117754610999773938
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3346644239416305965}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1991764993389845107}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5765002987134345664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3346644239416305965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Feedbacks: []
+  InitializationMode: 2
+  SafeMode: 3
+  Direction: 0
+  AutoChangeDirectionOnEnd: 0
+  AutoPlayOnStart: 0
+  AutoPlayOnEnable: 0
+  ForceTimescaleMode: 0
+  ForcedTimescaleMode: 1
+  DurationMultiplier: 1
+  RandomizeDuration: 0
+  RandomDurationMultiplier: {x: 0.5, y: 1.5}
+  DisplayFullDurationDetails: 0
+  PlayerTimescaleMode: 1
+  OnlyPlayIfWithinRange: 0
+  RangeCenter: {fileID: 0}
+  RangeDistance: 5
+  UseRangeFalloff: 0
+  RangeFalloff:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  RemapRangeFalloff: {x: 0, y: 1}
+  IgnoreRangeEvents: 0
+  CooldownDuration: 0
+  InitialDelay: 0
+  CanPlay: 1
+  CanPlayWhileAlreadyPlaying: 1
+  ChanceToPlay: 100
+  FeedbacksIntensity: 1
+  Events:
+    TriggerMMFeedbacksEvents: 0
+    TriggerUnityEvents: 1
+    OnPlay:
+      m_PersistentCalls:
+        m_Calls: []
+    OnPause:
+      m_PersistentCalls:
+        m_Calls: []
+    OnResume:
+      m_PersistentCalls:
+        m_Calls: []
+    OnRevert:
+      m_PersistentCalls:
+        m_Calls: []
+    OnComplete:
+      m_PersistentCalls:
+        m_Calls: []
+  DebugActive: 0
+  FeedbacksList:
+  - id: 0
+  KeepPlayModeChanges: 0
+  PerformanceMode: 0
+  ForceStopFeedbacksOnDisable: 1
+  references:
+    version: 1
+    00000000:
+      type: {class: MMF_DestinationTransform, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks}
+      data:
+        Active: 1
+        UniqueID: -1967121755
+        Label: Destination
+        ChannelMode: 0
+        Channel: 0
+        MMChannelDefinition: {fileID: 0}
+        Chance: 100
+        DisplayColor: {r: 0, g: 0, b: 0, a: 1}
+        Timing:
+          TimescaleMode: 0
+          ExcludeFromHoldingPauses: 0
+          ContributeToTotalDuration: 1
+          InitialDelay: 0
+          CooldownDuration: 0
+          InterruptsOnStop: 1
+          NumberOfRepeats: 0
+          RepeatForever: 0
+          DelayBetweenRepeats: 1
+          MMFeedbacksDirectionCondition: 0
+          PlayDirection: 0
+          ConstantIntensity: 0
+          UseIntensityInterval: 0
+          IntensityIntervalMin: 0
+          IntensityIntervalMax: 0
+          Sequence: {fileID: 0}
+          TrackID: 0
+          Quantized: 0
+          TargetBPM: 120
+        AutomatedTargetAcquisition:
+          Mode: 0
+          ChildIndex: 0
+        RandomizeOutput: 0
+        RandomMultiplier: {x: 0.8, y: 1}
+        RandomizeDuration: 0
+        RandomDurationMultiplier: {x: 0.5, y: 2}
+        UseRange: 0
+        RangeDistance: 5
+        UseRangeFalloff: 0
+        RangeFalloff:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 0
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        RemapRangeFalloff: {x: 0, y: 1}
+        Owner: {fileID: 5765002987134345664}
+        DebugActive: 0
+        TargetTransform: {fileID: 1124496401759698450}
+        ForceOrigin: 0
+        Origin: {fileID: 0}
+        Destination: {fileID: 2047241205932775296}
+        UseLocalPosition: 1
+        GlobalAnimationTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 4.4745507
+              outSlope: 4.4745507
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.020408163
+              value: 0.091317356
+              inSlope: 4.351268
+              outSlope: 4.351268
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.040816326
+              value: 0.17760277
+              inSlope: 4.107953
+              outSlope: 4.107953
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.06122449
+              value: 0.25898892
+              inSlope: 3.8711414
+              outSlope: 3.8711414
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.08163265
+              value: 0.33560854
+              inSlope: 3.640819
+              outSlope: 3.640819
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.10204082
+              value: 0.4075938
+              inSlope: 3.4169908
+              outSlope: 3.4169908
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.12244898
+              value: 0.47507757
+              inSlope: 3.1996655
+              outSlope: 3.1996655
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.14285715
+              value: 0.5381924
+              inSlope: 2.9888377
+              outSlope: 2.9888377
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.1632653
+              value: 0.59707093
+              inSlope: 2.7845092
+              outSlope: 2.7845092
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.18367347
+              value: 0.6518458
+              inSlope: 2.5866737
+              outSlope: 2.5866737
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.20408164
+              value: 0.7026495
+              inSlope: 2.3953354
+              outSlope: 2.3953354
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.2244898
+              value: 0.7496146
+              inSlope: 2.210495
+              outSlope: 2.210495
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.24489796
+              value: 0.79287374
+              inSlope: 2.0321524
+              outSlope: 2.0321524
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.26530612
+              value: 0.8325596
+              inSlope: 1.8603065
+              outSlope: 1.8603065
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.2857143
+              value: 0.86880463
+              inSlope: 1.694958
+              outSlope: 1.694958
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.30612245
+              value: 0.90174156
+              inSlope: 1.5361106
+              outSlope: 1.5361106
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.3265306
+              value: 0.931503
+              inSlope: 1.3837581
+              outSlope: 1.3837581
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.3469388
+              value: 0.9582215
+              inSlope: 1.2379018
+              outSlope: 1.2379018
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.36734694
+              value: 0.9820296
+              inSlope: 1.0985435
+              outSlope: 1.0985435
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.3877551
+              value: 1.00306
+              inSlope: 0.9656805
+              outSlope: 0.9656805
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.40816328
+              value: 1.0214452
+              inSlope: 0.83931506
+              outSlope: 0.83931506
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.42857143
+              value: 1.0373178
+              inSlope: 0.71945024
+              outSlope: 0.71945024
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.4489796
+              value: 1.0508105
+              inSlope: 0.6060827
+              outSlope: 0.6060827
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.46938777
+              value: 1.0620558
+              inSlope: 0.4992081
+              outSlope: 0.4992081
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.48979592
+              value: 1.0711863
+              inSlope: 0.39883232
+              outSlope: 0.39883232
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.5102041
+              value: 1.0783347
+              inSlope: 0.30495748
+              outSlope: 0.30495748
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.53061223
+              value: 1.0836335
+              inSlope: 0.2175781
+              outSlope: 0.2175781
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.5510204
+              value: 1.0872154
+              inSlope: 0.13669406
+              outSlope: 0.13669406
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.5714286
+              value: 1.0892129
+              inSlope: 0.062305637
+              outSlope: 0.062305637
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.59183675
+              value: 1.0897585
+              inSlope: -0.005581322
+              outSlope: -0.005581322
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.6122449
+              value: 1.0889851
+              inSlope: -0.06697294
+              outSlope: -0.06697294
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.63265306
+              value: 1.0870249
+              inSlope: -0.12186617
+              outSlope: -0.12186617
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.6530612
+              value: 1.084011
+              inSlope: -0.170261
+              outSlope: -0.170261
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.67346936
+              value: 1.0800755
+              inSlope: -0.21216291
+              outSlope: -0.21216291
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.6938776
+              value: 1.0753512
+              inSlope: -0.24756385
+              outSlope: -0.24756385
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.71428573
+              value: 1.0699708
+              inSlope: -0.27646673
+              outSlope: -0.27646673
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.7346939
+              value: 1.0640669
+              inSlope: -0.29887673
+              outSlope: -0.29887673
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.75510204
+              value: 1.0577718
+              inSlope: -0.3147854
+              outSlope: -0.3147854
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.7755102
+              value: 1.0512185
+              inSlope: -0.32419857
+              outSlope: -0.32419857
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.79591835
+              value: 1.0445392
+              inSlope: -0.3271158
+              outSlope: -0.3271158
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.81632656
+              value: 1.0378668
+              inSlope: -0.32352927
+              outSlope: -0.32352927
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.8367347
+              value: 1.0313339
+              inSlope: -0.31345066
+              outSlope: -0.31345066
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.85714287
+              value: 1.0250729
+              inSlope: -0.2968761
+              outSlope: -0.2968761
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.877551
+              value: 1.0192165
+              inSlope: -0.2738031
+              outSlope: -0.2738031
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.8979592
+              value: 1.0138973
+              inSlope: -0.24423176
+              outSlope: -0.24423176
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.9183673
+              value: 1.0092479
+              inSlope: -0.20816463
+              outSlope: -0.20816463
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.93877554
+              value: 1.0054008
+              inSlope: -0.16559939
+              outSlope: -0.16559939
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.9591837
+              value: 1.0024887
+              inSlope: -0.1165331
+              outSlope: -0.1165331
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.97959185
+              value: 1.0006443
+              inSlope: -0.060973972
+              outSlope: -0.060973972
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 1
+              value: 1
+              inSlope: -0.031572
+              outSlope: -0.031572
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        Duration: 0.2
+        AnimatePositionX: 1
+        AnimatePositionY: 1
+        AnimatePositionZ: 1
+        AnimateRotationX: 0
+        AnimateRotationY: 0
+        AnimateRotationZ: 0
+        AnimateRotationW: 0
+        AnimateScaleX: 0
+        AnimateScaleY: 0
+        AnimateScaleZ: 0
+        SeparatePositionCurve: 0
+        AnimatePositionTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 0.3
+              value: 1
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 1
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        SeparateRotationCurve: 0
+        AnimateRotationTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 0.3
+              value: 1
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 1
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        SeparateScaleCurve: 0
+        AnimateScaleTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 0.3
+              value: 1
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 1
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        GlobalAnimationCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        AnimateScaleCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        AnimatePositionCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        AnimateRotationCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
 --- !u!1 &3426903545096794539
 GameObject:
   m_ObjectHideFlags: 0
@@ -16037,6 +16890,8 @@ MonoBehaviour:
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _readLocalRotation: 0
   _setLocalRotation: 0
+  _clearLocalRotationOnDisable: 1
+  _maxDegreesDelta: 3
   _remapAngles: 0
   _remapAnglesOldMin: {x: 0, y: 0, z: 0}
   _remapAnglesOldMax: {x: 360, y: 360, z: 360}
@@ -16073,6 +16928,39 @@ Transform:
   - {fileID: 2114448392668177077}
   m_Father: {fileID: 7073329726129986620}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4339508171856371713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2509723621614378134}
+  m_Layer: 7
+  m_Name: Minimap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2509723621614378134
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4339508171856371713}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3614801428890648448}
+  - {fileID: 2047241205932775296}
+  - {fileID: 1124496401759698450}
+  m_Father: {fileID: 7265003986444444711}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4379650922927584773
 GameObject:
@@ -16722,6 +17610,36 @@ Transform:
   - {fileID: 392949985054318323}
   - {fileID: 863770675}
   m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4813179730597305926
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3614801428890648448}
+  m_Layer: 7
+  m_Name: Minimap (HUD position)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3614801428890648448
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4813179730597305926}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.07199955, z: 0.25000054}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2509723621614378134}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4990850813600765825
@@ -22390,6 +23308,38 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 0}
+--- !u!1 &5170219653991304387
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1991764993389845107}
+  m_Layer: 7
+  m_Name: Feedbacks
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1991764993389845107
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5170219653991304387}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7117754610999773938}
+  - {fileID: 8489976247026514684}
+  m_Father: {fileID: 1124496401759698450}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5186549032305905866
 GameObject:
   m_ObjectHideFlags: 0
@@ -22740,6 +23690,807 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &5461276325820665014
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8489976247026514684}
+  - component: {fileID: 3033368034392618734}
+  m_Layer: 7
+  m_Name: OverlayCloseFeedbacks
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8489976247026514684
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5461276325820665014}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1991764993389845107}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3033368034392618734
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5461276325820665014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Feedbacks: []
+  InitializationMode: 2
+  SafeMode: 3
+  Direction: 0
+  AutoChangeDirectionOnEnd: 0
+  AutoPlayOnStart: 0
+  AutoPlayOnEnable: 0
+  ForceTimescaleMode: 0
+  ForcedTimescaleMode: 1
+  DurationMultiplier: 1
+  RandomizeDuration: 0
+  RandomDurationMultiplier: {x: 0.5, y: 1.5}
+  DisplayFullDurationDetails: 0
+  PlayerTimescaleMode: 1
+  OnlyPlayIfWithinRange: 0
+  RangeCenter: {fileID: 0}
+  RangeDistance: 5
+  UseRangeFalloff: 0
+  RangeFalloff:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  RemapRangeFalloff: {x: 0, y: 1}
+  IgnoreRangeEvents: 0
+  CooldownDuration: 0
+  InitialDelay: 0
+  CanPlay: 1
+  CanPlayWhileAlreadyPlaying: 1
+  ChanceToPlay: 100
+  FeedbacksIntensity: 1
+  Events:
+    TriggerMMFeedbacksEvents: 0
+    TriggerUnityEvents: 1
+    OnPlay:
+      m_PersistentCalls:
+        m_Calls: []
+    OnPause:
+      m_PersistentCalls:
+        m_Calls: []
+    OnResume:
+      m_PersistentCalls:
+        m_Calls: []
+    OnRevert:
+      m_PersistentCalls:
+        m_Calls: []
+    OnComplete:
+      m_PersistentCalls:
+        m_Calls: []
+  DebugActive: 0
+  FeedbacksList:
+  - id: 0
+  KeepPlayModeChanges: 0
+  PerformanceMode: 0
+  ForceStopFeedbacksOnDisable: 1
+  references:
+    version: 1
+    00000000:
+      type: {class: MMF_DestinationTransform, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks}
+      data:
+        Active: 1
+        UniqueID: -1967121755
+        Label: Destination
+        ChannelMode: 0
+        Channel: 0
+        MMChannelDefinition: {fileID: 0}
+        Chance: 100
+        DisplayColor: {r: 0, g: 0, b: 0, a: 1}
+        Timing:
+          TimescaleMode: 0
+          ExcludeFromHoldingPauses: 0
+          ContributeToTotalDuration: 1
+          InitialDelay: 0
+          CooldownDuration: 0
+          InterruptsOnStop: 1
+          NumberOfRepeats: 0
+          RepeatForever: 0
+          DelayBetweenRepeats: 1
+          MMFeedbacksDirectionCondition: 0
+          PlayDirection: 0
+          ConstantIntensity: 0
+          UseIntensityInterval: 0
+          IntensityIntervalMin: 0
+          IntensityIntervalMax: 0
+          Sequence: {fileID: 0}
+          TrackID: 0
+          Quantized: 0
+          TargetBPM: 120
+        AutomatedTargetAcquisition:
+          Mode: 0
+          ChildIndex: 0
+        RandomizeOutput: 0
+        RandomMultiplier: {x: 0.8, y: 1}
+        RandomizeDuration: 0
+        RandomDurationMultiplier: {x: 0.5, y: 2}
+        UseRange: 0
+        RangeDistance: 5
+        UseRangeFalloff: 0
+        RangeFalloff:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 0
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        RemapRangeFalloff: {x: 0, y: 1}
+        Owner: {fileID: 3033368034392618734}
+        DebugActive: 0
+        TargetTransform: {fileID: 1124496401759698450}
+        ForceOrigin: 0
+        Origin: {fileID: 0}
+        Destination: {fileID: 3614801428890648448}
+        UseLocalPosition: 1
+        GlobalAnimationTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 9.848856
+              outSlope: 9.848856
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.020408163
+              value: 0.20099705
+              inSlope: 6.9282017
+              outSlope: 6.9282017
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.040816326
+              value: 0.28278375
+              inSlope: 3.516542
+              outSlope: 3.516542
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.06122449
+              value: 0.3445294
+              inSlope: 2.7671604
+              outSlope: 2.7671604
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.08163265
+              value: 0.39572906
+              inSlope: 2.3409588
+              outSlope: 2.3409588
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.10204082
+              value: 0.44007874
+              inSlope: 2.0519774
+              outSlope: 2.0519774
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.12244898
+              value: 0.47948325
+              inSlope: 1.8374996
+              outSlope: 1.8374996
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.14285715
+              value: 0.5150787
+              inSlope: 1.6690673
+              outSlope: 1.6690673
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.1632653
+              value: 0.54760844
+              inSlope: 1.5315437
+              outSlope: 1.5315437
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.18367347
+              value: 0.5775907
+              inSlope: 1.4159914
+              outSlope: 1.4159914
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.20408164
+              value: 0.605404
+              inSlope: 1.3167374
+              outSlope: 1.3167374
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.2244898
+              value: 0.6313351
+              inSlope: 1.2299801
+              outSlope: 1.2299801
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.24489796
+              value: 0.6556073
+              inSlope: 1.1530609
+              outSlope: 1.1530609
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.26530612
+              value: 0.6783988
+              inSlope: 1.084049
+              outSlope: 1.084049
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.2857143
+              value: 0.6998542
+              inSlope: 1.0215068
+              outSlope: 1.0215068
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.30612245
+              value: 0.72009295
+              inSlope: 0.964342
+              outSlope: 0.964342
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.3265306
+              value: 0.7392151
+              inSlope: 0.91169846
+              outSlope: 0.91169846
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.3469388
+              value: 0.75730515
+              inSlope: 0.86289626
+              outSlope: 0.86289626
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.36734694
+              value: 0.77443534
+              inSlope: 0.817395
+              outSlope: 0.817395
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.3877551
+              value: 0.7906682
+              inSlope: 0.7747518
+              outSlope: 0.7747518
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.40816328
+              value: 0.8060579
+              inSlope: 0.734599
+              outSlope: 0.734599
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.42857143
+              value: 0.8206518
+              inSlope: 0.6966313
+              outSlope: 0.6966313
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.4489796
+              value: 0.8344918
+              inSlope: 0.6605903
+              outSlope: 0.6605903
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.46938777
+              value: 0.8476147
+              inSlope: 0.6262583
+              outSlope: 0.6262583
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.48979592
+              value: 0.86005336
+              inSlope: 0.59344995
+              outSlope: 0.59344995
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.5102041
+              value: 0.87183714
+              inSlope: 0.5620006
+              outSlope: 0.5620006
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.53061223
+              value: 0.88299215
+              inSlope: 0.53176916
+              outSlope: 0.53176916
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.5510204
+              value: 0.893542
+              inSlope: 0.5026366
+              outSlope: 0.5026366
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.5714286
+              value: 0.90350795
+              inSlope: 0.47449052
+              outSlope: 0.47449052
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.59183675
+              value: 0.912909
+              inSlope: 0.44723445
+              outSlope: 0.44723445
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.6122449
+              value: 0.9217624
+              inSlope: 0.42078817
+              outSlope: 0.42078817
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.63265306
+              value: 0.930084
+              inSlope: 0.39507204
+              outSlope: 0.39507204
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.6530612
+              value: 0.9378878
+              inSlope: 0.3700145
+              outSlope: 0.3700145
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.67346936
+              value: 0.9451866
+              inSlope: 0.34555668
+              outSlope: 0.34555668
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.6938776
+              value: 0.95199215
+              inSlope: 0.32164255
+              outSlope: 0.32164255
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.71428573
+              value: 0.9583149
+              inSlope: 0.2982152
+              outSlope: 0.2982152
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.7346939
+              value: 0.9641642
+              inSlope: 0.2752313
+              outSlope: 0.2752313
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.75510204
+              value: 0.9695488
+              inSlope: 0.25265047
+              outSlope: 0.25265047
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.7755102
+              value: 0.97447646
+              inSlope: 0.23042303
+              outSlope: 0.23042303
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.79591835
+              value: 0.97895384
+              inSlope: 0.20851657
+              outSlope: 0.20851657
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.81632656
+              value: 0.98298734
+              inSlope: 0.18689515
+              outSlope: 0.18689515
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.8367347
+              value: 0.9865822
+              inSlope: 0.16552228
+              outSlope: 0.16552228
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.85714287
+              value: 0.98974335
+              inSlope: 0.14436814
+              outSlope: 0.14436814
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.877551
+              value: 0.9924748
+              inSlope: 0.12340242
+              outSlope: 0.12340242
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.8979592
+              value: 0.9947802
+              inSlope: 0.10259877
+              outSlope: 0.10259877
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.9183673
+              value: 0.9966625
+              inSlope: 0.081923544
+              outSlope: 0.081923544
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.93877554
+              value: 0.998124
+              inSlope: 0.06135209
+              outSlope: 0.06135209
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.9591837
+              value: 0.99916667
+              inSlope: 0.040859602
+              outSlope: 0.040859602
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.97959185
+              value: 0.99979174
+              inSlope: 0.020416657
+              outSlope: 0.020416657
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 1
+              value: 1
+              inSlope: 0.0102046775
+              outSlope: 0.0102046775
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        Duration: 0.3
+        AnimatePositionX: 1
+        AnimatePositionY: 1
+        AnimatePositionZ: 1
+        AnimateRotationX: 0
+        AnimateRotationY: 0
+        AnimateRotationZ: 0
+        AnimateRotationW: 0
+        AnimateScaleX: 0
+        AnimateScaleY: 0
+        AnimateScaleZ: 0
+        SeparatePositionCurve: 0
+        AnimatePositionTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 0.3
+              value: 1
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 1
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        SeparateRotationCurve: 0
+        AnimateRotationTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 0.3
+              value: 1
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 1
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        SeparateScaleCurve: 0
+        AnimateScaleTween:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 0.3
+              value: 1
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 1
+              value: 0
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        GlobalAnimationCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        AnimateScaleCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        AnimatePositionCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        AnimateRotationCurve:
+          serializedVersion: 2
+          m_Curve: []
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
 --- !u!1 &5496002828941773894
 GameObject:
   m_ObjectHideFlags: 0
@@ -23570,16 +25321,16 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6266807033874931565}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.072, z: 0.25000054}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.07199955, z: 0.25000054}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 162339389660353893}
   - {fileID: 8559044050560204755}
-  - {fileID: 4944558589552590849}
   - {fileID: 4360969640052789754}
-  m_Father: {fileID: 7265003986444444711}
-  m_RootOrder: 4
+  - {fileID: 1991764993389845107}
+  m_Father: {fileID: 2509723621614378134}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6281234742112583323
 GameObject:
@@ -25387,7 +27138,7 @@ Transform:
   - {fileID: 2711247591783983908}
   - {fileID: 4936108711428930162}
   - {fileID: 7073329726129986620}
-  - {fileID: 1124496401759698450}
+  - {fileID: 2509723621614378134}
   - {fileID: 281772354757565551}
   - {fileID: 7534361477877803264}
   - {fileID: 2948586884496874650}
@@ -28688,11 +30439,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
---- !u!4 &981458945698494185 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6347296434736609577, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
-  m_PrefabInstance: {fileID: 6163448547068399552}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6763227702262468176 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 599884813771948432, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
@@ -28704,6 +30450,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &981458945698494185 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6347296434736609577, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
+  m_PrefabInstance: {fileID: 6163448547068399552}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6543468985606383630
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -13556,7 +13556,7 @@ MonoBehaviour:
   blendMode: 1
   scaleMode: 0
   color: {r: 1, g: 1, b: 1, a: 1}
-  zTest: 8
+  zTest: 4
   zOffsetFactor: 0
   zOffsetUnits: 0
   generatedComponentHideFlags: 2
@@ -13589,7 +13589,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 0}
+  - {fileID: 2100000, guid: 628f131798f2fca4fbfa6881a9f300f3, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -13609,7 +13609,7 @@ MeshRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3650829453299661923
 GameObject:
@@ -27171,7 +27171,7 @@ Camera:
     height: 1
   near clip plane: 0.2
   far clip plane: 500
-  field of view: 55.48935
+  field of view: 65.07074
   orthographic: 0
   orthographic size: 5
   m_Depth: -1
@@ -29632,7 +29632,7 @@ MonoBehaviour:
   blendMode: 1
   scaleMode: 0
   color: {r: 0.8768357, g: 0.9150943, b: 0.37615073, a: 1}
-  zTest: 8
+  zTest: 4
   zOffsetFactor: 0
   zOffsetUnits: 0
   generatedComponentHideFlags: 2
@@ -29667,7 +29667,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 0}
+  - {fileID: 2100000, guid: 4d60ecf9a3a734347933d3c049e7e21b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -29687,7 +29687,7 @@ MeshRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8921646345825070386
 GameObject:

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -9061,6 +9061,7 @@ Transform:
   m_LocalScale: {x: 0.006, y: 0.006, z: 0.006}
   m_Children:
   - {fileID: 6780521088754864702}
+  - {fileID: 1262905525937274118}
   m_Father: {fileID: 4360969640052789754}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9088,9 +9089,11 @@ MonoBehaviour:
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
   _readLocalRotation: 1
   _setLocalRotation: 1
-  _remapAngles: 1
-  _remapAnglesMin: {x: 0, y: 0, z: 0}
-  _remapAnglesMax: {x: 10, y: 360, z: 10}
+  _remapAngles: 0
+  _remapAnglesOldMin: {x: 0, y: 0, z: 0}
+  _remapAnglesOldMax: {x: 360, y: 360, z: 360}
+  _remapAnglesNewMin: {x: 0, y: 0, z: 0}
+  _remapAnglesNewMax: {x: 360, y: 360, z: 360}
 --- !u!1 &2331793945456284132
 GameObject:
   m_ObjectHideFlags: 0
@@ -9182,6 +9185,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4360969640052789754}
+  - component: {fileID: 4812894782618110578}
   m_Layer: 7
   m_Name: Minimap (constant rotation offset)
   m_TagString: Untagged
@@ -9204,6 +9208,35 @@ Transform:
   m_Father: {fileID: 1124496401759698450}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+--- !u!114 &4812894782618110578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2360800453983378263}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83a28b539cad4ce0a0107cafc58c739c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _target:
+    ReferenceTypeSelector: 1
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 4f3c154bd5d34bd4e8e4d93472fefad9, type: 2}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  _transform:
+    ReferenceTypeSelector: 0
+    ReferenceValue_Transform: {fileID: 4360969640052789754}
+    ReferenceValue_TransformSceneReference: {fileID: 0}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  _readLocalRotation: 1
+  _setLocalRotation: 1
+  _remapAngles: 1
+  _remapAnglesOldMin: {x: 90, y: 0, z: 0}
+  _remapAnglesOldMax: {x: -90, y: 360, z: 360}
+  _remapAnglesNewMin: {x: 0, y: 0, z: 0}
+  _remapAnglesNewMax: {x: -180, y: 0, z: 0}
 --- !u!1 &2432463934219413715
 GameObject:
   m_ObjectHideFlags: 0
@@ -10723,6 +10756,87 @@ Transform:
   m_Father: {fileID: 42333560796704333}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2958682098552079448
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8710438696001077267}
+  - component: {fileID: 5433329536262700701}
+  - component: {fileID: 7568690214484774924}
+  m_Layer: 8
+  m_Name: Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8710438696001077267
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2958682098552079448}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0, y: -1.07, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1262905525937274118}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5433329536262700701
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2958682098552079448}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7568690214484774924
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2958682098552079448}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d735b086667086a428b31760152e0977, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &3089256189035123441
 GameObject:
   m_ObjectHideFlags: 0
@@ -15819,8 +15933,10 @@ MonoBehaviour:
   _readLocalRotation: 0
   _setLocalRotation: 0
   _remapAngles: 0
-  _remapAnglesMin: {x: 0, y: 0, z: 0}
-  _remapAnglesMax: {x: 360, y: 360, z: 360}
+  _remapAnglesOldMin: {x: 0, y: 0, z: 0}
+  _remapAnglesOldMax: {x: 360, y: 360, z: 360}
+  _remapAnglesNewMin: {x: 0, y: 0, z: 0}
+  _remapAnglesNewMax: {x: 360, y: 360, z: 360}
 --- !u!1 &4292042580474181362
 GameObject:
   m_ObjectHideFlags: 0
@@ -27794,6 +27910,88 @@ MonoBehaviour:
   _graphs:
   - {fileID: 1218375026740936388}
   - {fileID: 3299656091158701037}
+--- !u!1 &8994972268214093008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1262905525937274118}
+  - component: {fileID: 2499117005032351661}
+  - component: {fileID: 9032735139370982432}
+  m_Layer: 8
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1262905525937274118
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8994972268214093008}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8710438696001077267}
+  m_Father: {fileID: 4263997310979020706}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2499117005032351661
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8994972268214093008}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &9032735139370982432
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8994972268214093008}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: d735b086667086a428b31760152e0977, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &9083730211021722212
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -15961,7 +15961,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4292042580474181362}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.07400036, z: 0.25000054}
+  m_LocalPosition: {x: 0.05, y: 0.07400036, z: 0.25000054}
   m_LocalScale: {x: 0.010000001, y: 0.01, z: 0.010000001}
   m_Children:
   - {fileID: 8947045854311204284}
@@ -23465,8 +23465,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6266807033874931565}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.07132149, z: 0.5000011}
+  m_LocalRotation: {x: -0.17364825, y: 0, z: 0, w: 0.9848078}
+  m_LocalPosition: {x: 0, y: 0.17, z: 0.5000011}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 162339389660353893}
@@ -23475,7 +23475,7 @@ Transform:
   - {fileID: 4360969640052789754}
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: -20, y: 0, z: 0}
 --- !u!1 &6281234742112583323
 GameObject:
   m_ObjectHideFlags: 0
@@ -25315,7 +25315,7 @@ Camera:
     height: 1
   near clip plane: 0.2
   far clip plane: 500
-  field of view: 65.07074
+  field of view: 55.48935
   orthographic: 0
   orthographic size: 5
   m_Depth: -1
@@ -27922,12 +27922,12 @@ GameObject:
   - component: {fileID: 2499117005032351661}
   - component: {fileID: 9032735139370982432}
   m_Layer: 8
-  m_Name: Plane
+  m_Name: Debug Plane
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1262905525937274118
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -5523,6 +5523,50 @@ Transform:
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &603536171153513679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4944558589552590849}
+  - component: {fileID: 8362569841916225692}
+  m_Layer: 0
+  m_Name: Cull Outside
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4944558589552590849
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 603536171153513679}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1124496401759698450}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!135 &8362569841916225692
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 603536171153513679}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.05
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &641693477969724353
 GameObject:
   m_ObjectHideFlags: 0
@@ -8036,6 +8080,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b16b260343dd417aabd2e467dbfa0901, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  MinimapParameters: {fileID: 11400000, guid: fb356ad72f43032459506de3aafa682e, type: 2}
   _doCenterOnPlayer: 1
   _levelRoot:
     ReferenceTypeSelector: 2
@@ -8047,14 +8092,10 @@ MonoBehaviour:
     ReferenceValue_Transform: {fileID: 0}
     ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122, type: 2}
     ReferenceValue_GameObjectSceneReference: {fileID: 0}
-  _zoomLevel:
-    ReferenceTypeSelector: 1
-    ConstantValue: 0
-    ReferenceValue_FloatVariable: {fileID: 11400000, guid: 1ae640b574cc1b640a31642f1a91cd82, type: 2}
-    ReferenceValue_IntVariable: {fileID: 0}
-    ReferenceValue_EvaluateCurveVariable: {fileID: 0}
   _translationTarget: {fileID: 6780521088754864702}
   _scalingTarget: {fileID: 162339389660353893}
+  _cullOutside: {fileID: 8362569841916225692}
+  _zoomBaseline: 0.006
 --- !u!1 &1797728375059188022
 GameObject:
   m_ObjectHideFlags: 0
@@ -23222,6 +23263,7 @@ Transform:
   m_Children:
   - {fileID: 162339389660353893}
   - {fileID: 8559044050560204755}
+  - {fileID: 4944558589552590849}
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -15631,6 +15631,62 @@ MonoBehaviour:
           m_PreInfinity: 2
           m_PostInfinity: 2
           m_RotationOrder: 4
+--- !u!1 &4274290743911571786
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8559044050560204755}
+  - component: {fileID: 7766843860951723989}
+  m_Layer: 7
+  m_Name: Cone Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8559044050560204755
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4274290743911571786}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 9123840146911269337}
+  m_Father: {fileID: 1124496401759698450}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7766843860951723989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4274290743911571786}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83a28b539cad4ce0a0107cafc58c739c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _target:
+    ReferenceTypeSelector: 2
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 0}
+    ReferenceValue_GameObjectSceneReference: {fileID: 11400000, guid: 70c332354ecbb9c46bf117bd4c575bab, type: 2}
+  _transform:
+    ReferenceTypeSelector: 0
+    ReferenceValue_Transform: {fileID: 8559044050560204755}
+    ReferenceValue_TransformSceneReference: {fileID: 0}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  _readLocalRotation: 0
+  _setLocalRotation: 0
 --- !u!1 &4292042580474181362
 GameObject:
   m_ObjectHideFlags: 0
@@ -23165,6 +23221,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 162339389660353893}
+  - {fileID: 8559044050560204755}
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -27419,6 +27476,112 @@ Transform:
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8869123641515229079
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9123840146911269337}
+  - component: {fileID: 5835090513557069415}
+  - component: {fileID: 136225020722915539}
+  - component: {fileID: 4824272375582186805}
+  m_Layer: 7
+  m_Name: Cone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9123840146911269337
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8869123641515229079}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0.030000031, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8559044050560204755}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!114 &5835090513557069415
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8869123641515229079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1515c530359148419de26696a81599e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  meshOutOfDate: 1
+  blendMode: 1
+  scaleMode: 0
+  color: {r: 0.8768357, g: 0.9150943, b: 0.37615073, a: 1}
+  zTest: 4
+  zOffsetFactor: 0
+  zOffsetUnits: 0
+  generatedComponentHideFlags: 2
+  radius: 0.01
+  length: 0.02
+  sizeSpace: 0
+  fillCap: 1
+--- !u!33 &136225020722915539
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8869123641515229079}
+  m_Mesh: {fileID: 4300010, guid: 93e008a3a312f6041bb52f2c0413bc68, type: 3}
+--- !u!23 &4824272375582186805
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8869123641515229079}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 4d60ecf9a3a734347933d3c049e7e21b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &8921646345825070386
 GameObject:
   m_ObjectHideFlags: 0
@@ -28160,14 +28323,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
---- !u!198 &3728946144052914370 stripped
-ParticleSystem:
-  m_CorrespondingSourceObject: {fileID: 7597839329562230988, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
-  m_PrefabInstance: {fileID: 6543468985606383630}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &3561747769528798360 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7755986796828648598, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
+  m_PrefabInstance: {fileID: 6543468985606383630}
+  m_PrefabAsset: {fileID: 0}
+--- !u!198 &3728946144052914370 stripped
+ParticleSystem:
+  m_CorrespondingSourceObject: {fileID: 7597839329562230988, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
   m_PrefabInstance: {fileID: 6543468985606383630}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6947250416337299594

--- a/Assets/Entities/Player/Player.prefab
+++ b/Assets/Entities/Player/Player.prefab
@@ -5539,7 +5539,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &4944558589552590849
 Transform:
   m_ObjectHideFlags: 0
@@ -8095,7 +8095,7 @@ MonoBehaviour:
   _translationTarget: {fileID: 6780521088754864702}
   _scalingTarget: {fileID: 4263997310979020706}
   _cullOutside: {fileID: 8362569841916225692}
-  _zoomBaseline: 0.006
+  _zoomBaseline: 0.002
 --- !u!1 &1797728375059188022
 GameObject:
   m_ObjectHideFlags: 0
@@ -9058,7 +9058,7 @@ Transform:
   m_GameObject: {fileID: 2302739639425751954}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.006, y: 0.006, z: 0.006}
+  m_LocalScale: {x: 0.002, y: 0.002, z: 0.002}
   m_Children:
   - {fileID: 6780521088754864702}
   - {fileID: 1262905525937274118}
@@ -10254,7 +10254,7 @@ MonoBehaviour:
     Variable: {fileID: 11400000, guid: 2c6a9ec7ffcec724b83f7abc212de507, type: 2}
   _onPurchaseEvent: {fileID: 11400000, guid: 55866cc2117789d43af4b6db2f26f0ef, type: 2}
   _isGodModeEnabled: {fileID: 11400000, guid: c3845ac29ad76214893f2b304a42dcef, type: 2}
-  _enableLogs: {fileID: 0}
+  _enableLogs: 0
 --- !u!136 &936822692517190024
 CapsuleCollider:
   m_ObjectHideFlags: 8
@@ -12633,6 +12633,110 @@ MeshRenderer:
   m_RendererPriority: 0
   m_Materials:
   - {fileID: 2100000, guid: 6dd38d304963d664183dc12865638955, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3614506831279384262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1250745129949558345}
+  - component: {fileID: 6887960622987622867}
+  - component: {fileID: 2110001026863432735}
+  - component: {fileID: 6414518855999523003}
+  m_Layer: 8
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1250745129949558345
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3614506831279384262}
+  m_LocalRotation: {x: -0.7071068, y: 0.000000014901161, z: 0.000000014901161, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.002, y: 0.002, z: 0.002}
+  m_Children: []
+  m_Father: {fileID: 8559044050560204755}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6887960622987622867
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3614506831279384262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0227a202d6d1e944888db8f30673549b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  meshOutOfDate: 1
+  blendMode: 1
+  scaleMode: 0
+  color: {r: 1, g: 1, b: 1, a: 1}
+  zTest: 4
+  zOffsetFactor: 0
+  zOffsetUnits: 0
+  generatedComponentHideFlags: 2
+  radius: 1
+  radiusSpace: 0
+--- !u!33 &2110001026863432735
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3614506831279384262}
+  m_Mesh: {fileID: 4300002, guid: 93e008a3a312f6041bb52f2c0413bc68, type: 3}
+--- !u!23 &6414518855999523003
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3614506831279384262}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 628f131798f2fca4fbfa6881a9f300f3, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -15886,7 +15990,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8559044050560204755}
   - component: {fileID: 7766843860951723989}
-  m_Layer: 7
+  m_Layer: 8
   m_Name: Cone Container
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15905,6 +16009,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 9123840146911269337}
+  - {fileID: 1250745129949558345}
   m_Father: {fileID: 1124496401759698450}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -15915,7 +16020,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4274290743911571786}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 83a28b539cad4ce0a0107cafc58c739c, type: 3}
   m_Name: 
@@ -23386,7 +23491,7 @@ Transform:
   m_GameObject: {fileID: 6250237178606343246}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.006, y: 0.006, z: 0.006}
+  m_LocalScale: {x: 0.002, y: 0.002, z: 0.002}
   m_Children: []
   m_Father: {fileID: 1124496401759698450}
   m_RootOrder: 0
@@ -23416,16 +23521,16 @@ MonoBehaviour:
   _rotationNoiseScale: {x: 1, y: 1, z: 1}
   _rotationNoiseForceMode: 5
   _rotationNoiseAngularDifferenceThreshold: 50
-  _useXValuesForAllAxes: 1
+  _useXValuesForAllAxes: 0
   _xAxisP: 0.1
   _xAxisI: 0
-  _xAxisD: 0.05
-  _yAxisP: 0
+  _xAxisD: 0.1
+  _yAxisP: 0.1
   _yAxisI: 0
-  _yAxisD: 0
-  _zAxisP: 0
+  _yAxisD: 0.05
+  _zAxisP: 0.1
   _zAxisI: 0
-  _zAxisD: 0
+  _zAxisD: 0.1
 --- !u!54 &5520238887478614414
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -23465,8 +23570,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6266807033874931565}
-  m_LocalRotation: {x: -0.17364825, y: 0, z: 0, w: 0.9848078}
-  m_LocalPosition: {x: 0, y: 0.17, z: 0.5000011}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.072, z: 0.25000054}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 162339389660353893}
@@ -23475,7 +23580,7 @@ Transform:
   - {fileID: 4360969640052789754}
   m_Father: {fileID: 7265003986444444711}
   m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: -20, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6281234742112583323
 GameObject:
   m_ObjectHideFlags: 0
@@ -27739,7 +27844,7 @@ GameObject:
   - component: {fileID: 5835090513557069415}
   - component: {fileID: 136225020722915539}
   - component: {fileID: 4824272375582186805}
-  m_Layer: 7
+  m_Layer: 8
   m_Name: Cone
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -27754,7 +27859,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8869123641515229079}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0.030000031, z: 0}
+  m_LocalPosition: {x: 0, y: 0.007, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8559044050560204755}
@@ -27780,8 +27885,8 @@ MonoBehaviour:
   zOffsetFactor: 0
   zOffsetUnits: 0
   generatedComponentHideFlags: 2
-  radius: 0.01
-  length: 0.02
+  radius: 0.0015
+  length: 0.006
   sizeSpace: 0
   fillCap: 1
 --- !u!33 &136225020722915539
@@ -28398,14 +28503,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 205932039de1d994aa76cb572aefc9f9, type: 3}
---- !u!4 &2794262310649021554 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1384928679184904386, guid: 205932039de1d994aa76cb572aefc9f9, type: 3}
-  m_PrefabInstance: {fileID: 3890960061709579440}
-  m_PrefabAsset: {fileID: 0}
 --- !u!198 &2599902467193343756 stripped
 ParticleSystem:
   m_CorrespondingSourceObject: {fileID: 1291339071860702140, guid: 205932039de1d994aa76cb572aefc9f9, type: 3}
+  m_PrefabInstance: {fileID: 3890960061709579440}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2794262310649021554 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1384928679184904386, guid: 205932039de1d994aa76cb572aefc9f9, type: 3}
   m_PrefabInstance: {fileID: 3890960061709579440}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5350706952515162931
@@ -28656,14 +28761,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
---- !u!4 &3561747769528798360 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7755986796828648598, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
-  m_PrefabInstance: {fileID: 6543468985606383630}
-  m_PrefabAsset: {fileID: 0}
 --- !u!198 &3728946144052914370 stripped
 ParticleSystem:
   m_CorrespondingSourceObject: {fileID: 7597839329562230988, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
+  m_PrefabInstance: {fileID: 6543468985606383630}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3561747769528798360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7755986796828648598, guid: 23dc9730189695248b503458e84c2c9b, type: 3}
   m_PrefabInstance: {fileID: 6543468985606383630}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6947250416337299594

--- a/Assets/Input/GameInputActions.inputactions
+++ b/Assets/Input/GameInputActions.inputactions
@@ -499,7 +499,7 @@
                 {
                     "name": "",
                     "id": "994d7f84-9830-4033-9169-2271d837c885",
-                    "path": "<Keyboard>/t",
+                    "path": "<Keyboard>/m",
                     "interactions": "",
                     "processors": "",
                     "groups": "Keyboard&Mouse",

--- a/Assets/Input/GameInputActions.inputactions
+++ b/Assets/Input/GameInputActions.inputactions
@@ -105,6 +105,15 @@
                     "initialStateCheck": false
                 },
                 {
+                    "name": "ToggleMinimap",
+                    "type": "Button",
+                    "id": "940d5ece-d903-4016-9b48-7c74cf8494d3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
                     "name": "ToggleStore",
                     "type": "Button",
                     "id": "f17c030a-4610-47b9-815e-6bb0f29d51be",
@@ -486,6 +495,28 @@
                     "action": "ToggleUpgradeStore",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "994d7f84-9830-4033-9169-2271d837c885",
+                    "path": "<Keyboard>/t",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ToggleMinimap",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "17e92c95-40fd-4fb6-a08b-cb4bcd7a0312",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ToggleMinimap",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         },
@@ -623,6 +654,15 @@
                     "name": "ToggleStore",
                     "type": "Button",
                     "id": "5c169e85-ffde-4ad7-a20f-e271e539f8b7",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleMinimap",
+                    "type": "Button",
+                    "id": "e8d72abc-e38b-4515-810f-e25b0ba96f4d",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "Press",
@@ -1014,6 +1054,28 @@
                     "action": "ToggleStore",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4b576463-93fe-45c3-85b5-32137113e3f2",
+                    "path": "<Keyboard>/t",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ToggleMinimap",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8629e772-430c-44ed-ab02-e36309d4643b",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ToggleMinimap",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         },
@@ -1061,6 +1123,15 @@
                     "name": "ToggleStore",
                     "type": "Button",
                     "id": "388fac39-0992-4d29-8276-643eeb127403",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleMinimap",
+                    "type": "Button",
+                    "id": "81a75306-a8bc-4ef2-ad4c-77f4f5216088",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "Press",
@@ -1252,6 +1323,28 @@
                     "processors": "InvertVector2(invertX=false)",
                     "groups": "Keyboard&Mouse",
                     "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "abdc9a55-e2da-4d0e-b79e-a1bd80a2647a",
+                    "path": "<Keyboard>/t",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ToggleMinimap",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b18b4c8d-a3a0-4bd3-b426-eb048d217580",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ToggleMinimap",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scenes/Levels/Level_Cave_0.unity
+++ b/Assets/Scenes/Levels/Level_Cave_0.unity
@@ -123,6 +123,36 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &48310055
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 48310056}
+  m_Layer: 0
+  m_Name: Minimap (Debug only)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &48310056
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48310055}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children: []
+  m_Father: {fileID: 771419350}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &119103842
 GameObject:
   m_ObjectHideFlags: 0
@@ -618,6 +648,13 @@ MonoBehaviour:
   _showTraversabilityCheck: 1
   _generateDebugObjects: 1
   _debugObjectsContainer: {fileID: 1191531237}
+  _generateMinimap: 1
+  _minimapObjectsContainer:
+    ReferenceTypeSelector: 1
+    ReferenceValue_Transform: {fileID: 0}
+    ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 38c36189f686df949aa9c03df030f995, type: 2}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  MinimapParameters: {fileID: 11400000, guid: fb356ad72f43032459506de3aafa682e, type: 2}
   GizmoColorScheme_Inner: 6
   GizmoColorScheme_Outer: 5
   DebugNodeColor_Default: {r: 1, g: 1, b: 1, a: 0.29803923}
@@ -668,6 +705,7 @@ Transform:
   m_Children:
   - {fileID: 1297833593}
   - {fileID: 1191531237}
+  - {fileID: 48310056}
   - {fileID: 1231575174}
   - {fileID: 1496774519}
   - {fileID: 820661969}
@@ -720,7 +758,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 771419350}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1164083038
 PrefabInstance:
@@ -1010,7 +1048,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 771419350}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1255605503
 GameObject:
@@ -1437,7 +1475,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 771419350}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!850595691 &1498019911
 LightingSettings:

--- a/Assets/Scenes/Levels/Level_Cave_1.unity
+++ b/Assets/Scenes/Levels/Level_Cave_1.unity
@@ -618,6 +618,13 @@ MonoBehaviour:
   _showTraversabilityCheck: 1
   _generateDebugObjects: 1
   _debugObjectsContainer: {fileID: 1191531237}
+  _generateMinimap: 1
+  _minimapObjectsContainer:
+    ReferenceTypeSelector: 1
+    ReferenceValue_Transform: {fileID: 1078107753}
+    ReferenceValue_TransformSceneReference: {fileID: 11400000, guid: 38c36189f686df949aa9c03df030f995, type: 2}
+    ReferenceValue_GameObjectSceneReference: {fileID: 0}
+  MinimapParameters: {fileID: 11400000, guid: fb356ad72f43032459506de3aafa682e, type: 2}
   GizmoColorScheme_Inner: 6
   GizmoColorScheme_Outer: 5
   DebugNodeColor_Default: {r: 1, g: 1, b: 1, a: 0.29803923}
@@ -668,6 +675,7 @@ Transform:
   m_Children:
   - {fileID: 1297833593}
   - {fileID: 1191531237}
+  - {fileID: 1078107753}
   - {fileID: 1231575174}
   - {fileID: 1496774519}
   - {fileID: 820661969}
@@ -720,7 +728,37 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 771419350}
-  m_RootOrder: 4
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1078107752
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1078107753}
+  m_Layer: 0
+  m_Name: Minimap (Debug only)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1078107753
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1078107752}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_Children: []
+  m_Father: {fileID: 771419350}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1164083038
 PrefabInstance:
@@ -1010,7 +1048,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 771419350}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1255605503
 GameObject:
@@ -1432,7 +1470,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 771419350}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!850595691 &1498019911
 LightingSettings:

--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -605,7 +605,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-2616230
+  m_Name: pb_Mesh-7688958
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1821,7 +1821,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-2616206
+  m_Name: pb_Mesh-7688934
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2369,7 +2369,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-2616242
+  m_Name: pb_Mesh-7688970
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2635,7 +2635,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-2616338
+  m_Name: pb_Mesh-7689066
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2933,7 +2933,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-2616218
+  m_Name: pb_Mesh-7688946
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2

--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -354,6 +354,108 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5881633211758279697, guid: 54aa09e24ea6dc84f85b5feb44f0173b, type: 3}
   m_PrefabInstance: {fileID: 5881633211761706666}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &113075822
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1451645147}
+    m_Modifications:
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5413178696439222471, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+      propertyPath: m_Name
+      value: HUD_Minimap
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+--- !u!224 &113075823 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5413178696439222470, guid: 601db8ec67f70c446b3afeb1c81521a1, type: 3}
+  m_PrefabInstance: {fileID: 113075822}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &187986235
 GameObject:
   m_ObjectHideFlags: 0
@@ -1420,7 +1522,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649190723377008977, guid: 53e21db58897cb145ad955e037ed5d23, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 8649190723377008977, guid: 53e21db58897cb145ad955e037ed5d23, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1734,7 +1836,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649190723377008977, guid: 8ef6683c04663884ba383f9a74f1ce6b, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 8649190723377008977, guid: 8ef6683c04663884ba383f9a74f1ce6b, type: 3}
       propertyPath: m_AnchorMax.x
@@ -2544,7 +2646,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7497832697849430400, guid: 0154eb947532d164695cb41a7b6d2714, type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 7497832697849430400, guid: 0154eb947532d164695cb41a7b6d2714, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3184,6 +3286,7 @@ RectTransform:
   m_Children:
   - {fileID: 63945403}
   - {fileID: 648554344}
+  - {fileID: 113075823}
   - {fileID: 1995528497}
   - {fileID: 1224168177}
   - {fileID: 1975932446}
@@ -4321,7 +4424,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3052951379363391434, guid: 20557b914976f764cabce44dadb20792, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3052951379363391434, guid: 20557b914976f764cabce44dadb20792, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5335,7 +5438,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4625213752137676958, guid: d3ed24f7e1c713e42a19d9a207d972b8, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4625213752137676958, guid: d3ed24f7e1c713e42a19d9a207d972b8, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5832,7 +5935,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6358346554369937829, guid: f9ac06d723896cb46a38bfc321fd0bf9, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 6358346554369937829, guid: f9ac06d723896cb46a38bfc321fd0bf9, type: 3}
       propertyPath: m_AnchorMax.x
@@ -5950,7 +6053,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7009471845935833992, guid: 43016429ae8e8524fb81570696bcccdc, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7009471845935833992, guid: 43016429ae8e8524fb81570696bcccdc, type: 3}
       propertyPath: m_AnchorMax.x
@@ -6334,7 +6437,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1628494709503327830, guid: 881dab082e963694f92ae4e78b8a88a0, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1628494709503327830, guid: 881dab082e963694f92ae4e78b8a88a0, type: 3}
       propertyPath: m_AnchorMax.x
@@ -7327,7 +7430,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8649190723377008977, guid: 63b40a4c395028042b809bf2c2b73aba, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8649190723377008977, guid: 63b40a4c395028042b809bf2c2b73aba, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -605,7 +605,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-153046
+  m_Name: pb_Mesh-2616230
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1821,7 +1821,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-153022
+  m_Name: pb_Mesh-2616206
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2369,7 +2369,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-153058
+  m_Name: pb_Mesh-2616242
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2635,7 +2635,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-153154
+  m_Name: pb_Mesh-2616338
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2933,7 +2933,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-153034
+  m_Name: pb_Mesh-2616218
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -3308,6 +3308,8 @@ MonoBehaviour:
     sceneValue: {fileID: 1772095150}
   - sceneReference: {fileID: 11400000, guid: cbcd2f5fac878f349b8e0f07ca61e56b, type: 2}
     sceneValue: {fileID: 587341615}
+  - sceneReference: {fileID: 11400000, guid: 38c36189f686df949aa9c03df030f995, type: 2}
+    sceneValue: {fileID: 3835178114251414926}
   GameObjectSceneList:
   - sceneReference: {fileID: 11400000, guid: fb7b2e3ba8a4e724aa1716fcc22f0007, type: 2}
     sceneValue: {fileID: 3835178114251414923}
@@ -5309,6 +5311,11 @@ Transform:
 --- !u!4 &3835178114251414925 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7730667928466908284, guid: ccceb3b5f456b79488302c32fa59a2c1, type: 3}
+  m_PrefabInstance: {fileID: 3835178114251414922}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &3835178114251414926 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6780521088754864702, guid: ccceb3b5f456b79488302c32fa59a2c1, type: 3}
   m_PrefabInstance: {fileID: 3835178114251414922}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4625213751201475183

--- a/Assets/Scenes/MainGame.unity
+++ b/Assets/Scenes/MainGame.unity
@@ -191,7 +191,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh76768
+  m_Name: pb_Mesh667642
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -605,7 +605,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-7688958
+  m_Name: pb_Mesh-7676524
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1821,7 +1821,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-7688934
+  m_Name: pb_Mesh-7676500
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2369,7 +2369,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-7688970
+  m_Name: pb_Mesh-7676536
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2635,7 +2635,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-7689066
+  m_Name: pb_Mesh-7676632
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2933,7 +2933,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-7688946
+  m_Name: pb_Mesh-7676512
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -3470,7 +3470,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1772095149}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -68.75, y: -4.27, z: -35.35}
+  m_LocalPosition: {x: -42.75, y: -12.75, z: -42.75}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Scripts/CaveV2/CaveGenComponentV2.cs
+++ b/Assets/Scripts/CaveV2/CaveGenComponentV2.cs
@@ -682,6 +682,14 @@ namespace BML.Scripts.CaveV2
             // TODO more intelligent logic
             foreach (var caveGraphVertex in caveGraph.Vertices)
             {
+                if (caveGraphVertex == caveGraph.StartNode
+                    || caveGraphVertex == caveGraph.EndNode
+                    || caveGraphVertex == caveGraph.MerchantNode
+                ) {
+                    caveGraphVertex.NodeType = CaveNodeType.Medium;
+                    continue;
+                }
+                
                 // Rooms with only one connection (dead ends) are large rooms
                 int numEdges = caveGraph.AdjacentEdges(caveGraphVertex).Count();
                 if (numEdges == 1)

--- a/Assets/Scripts/CaveV2/CaveGenComponentV2.cs
+++ b/Assets/Scripts/CaveV2/CaveGenComponentV2.cs
@@ -1068,51 +1068,28 @@ namespace BML.Scripts.CaveV2
                 
                 // Get debug component
                 var debugComponent = newGameObject.GetComponent<CaveNodeDataMinimapComponent>();
-                debugComponent.CaveNodeData = caveNodeData;
-                debugComponent.CaveGenerator = this;
-                debugComponent.MinimapController = minimapController;
+                debugComponent.Initialize(caveNodeData, this, minimapController);
                 
                 OnAfterUpdatePlayerDistance += debugComponent.UpdatePlayerOccupied;
                 
-                UnityEditorInternal.InternalEditorUtility.SetIsInspectorExpanded(debugComponent.OuterRenderer, false);
+                UnityEditorInternal.InternalEditorUtility.SetIsInspectorExpanded(debugComponent.DiscoveredRenderer, false);
             }
             
             // Spawn at each edge
             foreach (var caveNodeConnectionData in _caveGraph.Edges)
             {
-                // Calculate tunnel position
-                var sourceTargetDiff = (caveNodeConnectionData.Target.LocalPosition -
-                                        caveNodeConnectionData.Source.LocalPosition);
-                var sourceTargetDiffProjectedToGroundNormalized = Vector3.ProjectOnPlane(sourceTargetDiff, Vector3.up).normalized;
-                
-                var edgeDiff = (caveNodeConnectionData.Target.LocalPosition - caveNodeConnectionData.Source.LocalPosition);
-                var edgeMidPosition = caveNodeConnectionData.Source.LocalPosition + edgeDiff / 2;
-                var edgeRotation = Quaternion.LookRotation(edgeDiff);
-                var edgeLength = edgeDiff.magnitude;
-                var localScale = new Vector3(0.1f, 0.1f, edgeLength);
-                // Debug.Log($"Edge length: EdgeLengthRaw {caveNodeConnectionData.Length} | Result Edge Length {edgeLength} | Source {caveNodeConnectionData.Source.Size} | Target {caveNodeConnectionData.Target.Size}");
-
                 // Spawn new game object
                 GameObject newGameObject = GameObjectUtils.SafeInstantiate(
                     true,
                     MinimapParameters.PrefabCaveNodeConnection,
                     _minimapObjectsContainer.Value);
-                // newGameObject.transform.SetPositionAndRotation(edgeMidPosition, edgeRotation);
-                // newGameObject.transform.position = edgeMidPosition;
-                // newGameObject.transform.localScale = localScale;
                 
                 // Get debug component
                 var debugComponent = newGameObject.GetComponent<CaveNodeConnectionDataMinimapComponent>();
-                debugComponent.CaveNodeConnectionData = caveNodeConnectionData;
-                debugComponent.CaveGenerator = this;
-                debugComponent.MinimapController = minimapController;
+                debugComponent.Initialize(caveNodeConnectionData, this, minimapController);
                 
                 OnAfterUpdatePlayerDistance += debugComponent.UpdatePlayerOccupied;
-
-                // Set shape renderer component parameters
-                debugComponent.Line.Start = caveNodeConnectionData.Source.LocalPosition;
-                debugComponent.Line.End = caveNodeConnectionData.Target.LocalPosition;
-                debugComponent.Line.Color = DebugNodeColor_Default;
+                
                 UnityEditorInternal.InternalEditorUtility.SetIsInspectorExpanded(debugComponent.Line, false);
             }
         }

--- a/Assets/Scripts/CaveV2/CaveGenComponentV2.cs
+++ b/Assets/Scripts/CaveV2/CaveGenComponentV2.cs
@@ -1021,7 +1021,7 @@ namespace BML.Scripts.CaveV2
         {
             if (EnableLogs) Debug.Log("Cave Graph: Destroying minimap objects");
             
-            if (_minimapObjectsContainer == null) return;
+            if (_minimapObjectsContainer == null || _minimapObjectsContainer.Value == null) return;
             
             var minimapObjects = Enumerable.Range(0, _minimapObjectsContainer.Value.childCount)
                 .Select(i => _minimapObjectsContainer.Value.GetChild(i).gameObject)

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap.meta
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8d82972825a54345a3bd9bff585ea5f6
+timeCreated: 1678124202

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
@@ -1,6 +1,8 @@
-﻿using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
+﻿using BML.ScriptableObjectCore.Scripts.Variables;
+using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
 using BML.Scripts.CaveV2.CaveGraph.NodeData;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 {
@@ -29,8 +31,8 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 
         [SerializeField] public SafeFloatValueReference ZoomLevel;
 
-        [SerializeField] public bool RestrictMapRadius = true;
-        [SerializeField] public float MapPlayerRadius = 30f;
+        [FormerlySerializedAs("RestrictMapRadius")] [SerializeField] public BoolReference OpenMapOverlay;
+        [SerializeField, Tooltip("Radius to restrict minimap when overlay is NOT open.")] public float MapPlayerRadius = 30f;
 
         #endregion
 

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+
+namespace BML.Scripts.CaveV2.CaveGraph.Minimap
+{
+    [CreateAssetMenu(fileName = "caveMinimapParameters", menuName = "BML/Cave Gen/Minimap Parameters", order = 0)]
+    public class CaveMinimapParameters : ScriptableObject
+    {
+        #region Inspector
+
+        [SerializeField] public GameObject PrefabCaveNode;
+        [SerializeField] public GameObject PrefabCaveNodeConnection;
+
+        [SerializeField] public Color DefaultColor;
+        [SerializeField] public Color VisitedColor;
+
+        #endregion
+
+        #region Unity lifecycle
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
@@ -1,4 +1,5 @@
 ﻿using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
+using BML.Scripts.CaveV2.CaveGraph.NodeData;
 using UnityEngine;
 
 namespace BML.Scripts.CaveV2.CaveGraph.Minimap
@@ -16,6 +17,16 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         [SerializeField] public Color VisitedColor;
         [SerializeField] public Color OccupiedColor;
 
+        [SerializeField] public float LineConnectionEndOffset = 0f;
+        [SerializeField] public float RelativeScale_Unassigned = 0.5f;
+        [SerializeField] public float RelativeScale_Small = 0.5f;
+        [SerializeField] public float RelativeScale_Medium = 0.75f;
+        [SerializeField] public float RelativeScale_Large = 1f;
+        
+        [SerializeField] public Color Color_StartRoom = Color.green;
+        [SerializeField] public Color Color_EndRoom = Color.red;
+        [SerializeField] public Color Color_MerchantRoom = Color.magenta;
+
         [SerializeField] public SafeFloatValueReference ZoomLevel;
 
         [SerializeField] public bool RestrictMapRadius = true;
@@ -24,6 +35,30 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         #endregion
 
         #region Unity lifecycle
+
+        #endregion
+
+        #region Public interface
+
+        public float GetNodeTypeRelativeScale(CaveNodeType nodeType)
+        {
+            switch (nodeType)
+            {
+                default:
+                case CaveNodeType.Unassigned:
+                    return RelativeScale_Unassigned;
+                    break;
+                case CaveNodeType.Small:
+                    return RelativeScale_Small;
+                    break;
+                case CaveNodeType.Medium:
+                    return RelativeScale_Medium;
+                    break;
+                case CaveNodeType.Large:
+                    return RelativeScale_Large;
+                    break;
+            }
+        }
 
         #endregion
     }

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
+using UnityEngine;
 
 namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 {
@@ -10,8 +11,15 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         [SerializeField] public GameObject PrefabCaveNode;
         [SerializeField] public GameObject PrefabCaveNodeConnection;
 
-        [SerializeField] public Color DefaultColor;
+        [SerializeField] public Color CulledColor;
+        [SerializeField] public Color VisibleColor;
         [SerializeField] public Color VisitedColor;
+        [SerializeField] public Color OccupiedColor;
+
+        [SerializeField] public SafeFloatValueReference ZoomLevel;
+
+        [SerializeField] public bool RestrictMapRadius = true;
+        [SerializeField] public float MapPlayerRadius = 30f;
 
         #endregion
 

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs.meta
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveMinimapParameters.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 52eeccc75c404f2f95692325b05cffb8
+timeCreated: 1678132021

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs
@@ -34,10 +34,10 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
             {
                 color = CaveGenerator.MinimapParameters.CulledColor;
             }
-            // else if (caveNodeConnectionData.PlayerOccupied)
-            // {
-            //     color = MinimapController.MinimapParameters.OccupiedColor;
-            // }
+            else if (caveNodeConnectionData.PlayerOccupied)
+            {
+                color = MinimapController.MinimapParameters.OccupiedColor;
+            }
             else if (caveNodeConnectionData.PlayerVisited)
             {
                 color = MinimapController.MinimapParameters.VisitedColor;

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs
@@ -22,6 +22,11 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
             // UpdatePlayerOccupied();
         }
 
+        private void OnDestroy()
+        {
+            MinimapController.MinimapParameters.OpenMapOverlay.Unsubscribe(UpdatePlayerOccupied);
+        }
+
         #endregion
 
         public void Initialize(CaveNodeConnectionData caveNodeConnectionData, CaveGenComponentV2 caveGenerator, MinimapController minimapController)
@@ -31,6 +36,9 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
             MinimapController = minimapController;
             
             UpdateLinePosition();
+            
+            MinimapController.MinimapParameters.OpenMapOverlay.Unsubscribe(UpdatePlayerOccupied);
+            MinimapController.MinimapParameters.OpenMapOverlay.Subscribe(UpdatePlayerOccupied);
         }
 
         private Color GetNodeColor(CaveNodeConnectionData caveNodeConnectionData)
@@ -41,10 +49,12 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
             float playerDistanceFac = 1f - Mathf.Clamp01((float)caveNodeConnectionData.PlayerDistance / 2f);
             alphaOverride = (playerDistanceFac * 0.9f) + 0.1f;
             
-            bool isInBounds = MinimapController.IsInBounds(caveNodeConnectionData.Source.DirectPlayerDistance)
-                              || MinimapController.IsInBounds(caveNodeConnectionData.Target.DirectPlayerDistance);
-            if (MinimapController.MinimapParameters.RestrictMapRadius && !isInBounds)
-            {
+            if (!MinimapController.MinimapParameters.OpenMapOverlay.Value 
+                && !(
+                    MinimapController.IsInBounds(caveNodeConnectionData.Source.DirectPlayerDistance)
+                    || MinimapController.IsInBounds(caveNodeConnectionData.Target.DirectPlayerDistance)
+                )
+            ) {
                 color = CaveGenerator.MinimapParameters.CulledColor;
                 alphaOverride = null;
             }
@@ -66,16 +76,28 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
                 alphaOverride = null;
             }
             
+            Color newColor = new Color(color.r, color.g, color.b, alphaOverride ?? color.a);
+            return newColor;
             color.a = (alphaOverride ?? color.a);
-
             return color;
         }
 
+        /// <summary>
+        /// Returns 0 if node not visited, so that the tunnel is longer and more obvious.
+        /// </summary>
+        /// <param name="caveNodeData"></param>
+        private float GetNodeDisplayScale(CaveNodeData caveNodeData)
+        {
+            return (!caveNodeData.PlayerVisitedAdjacent 
+                ? 0 
+                : MinimapController.MinimapParameters.GetNodeTypeRelativeScale(caveNodeData.NodeType));
+        }
+        
         public void UpdateLinePosition()
         {
             Vector3 sourceToTargetNormalized = (CaveNodeConnectionData.Target.LocalPosition - CaveNodeConnectionData.Source.LocalPosition).normalized;
-            float sourceRelativeScale = MinimapController.MinimapParameters.GetNodeTypeRelativeScale(CaveNodeConnectionData.Source.NodeType);
-            float targetRelativeScale = MinimapController.MinimapParameters.GetNodeTypeRelativeScale(CaveNodeConnectionData.Target.NodeType);
+            float sourceRelativeScale = GetNodeDisplayScale(CaveNodeConnectionData.Source);
+            float targetRelativeScale = GetNodeDisplayScale(CaveNodeConnectionData.Target);
             Vector3 baseOffset = sourceToTargetNormalized * MinimapController.MinimapParameters.LineConnectionEndOffset; 
             Line.Start = CaveNodeConnectionData.Source.LocalPosition + (sourceRelativeScale * baseOffset);
             Line.End = CaveNodeConnectionData.Target.LocalPosition - (targetRelativeScale * baseOffset);

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using BML.Scripts.CaveV2.CaveGraph.NodeData;
+using BML.Scripts.Utils;
+using Shapes;
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+namespace BML.Scripts.CaveV2.CaveGraph.Minimap
+{
+    public class CaveNodeConnectionDataMinimapComponent : MonoBehaviour
+    {
+        [ReadOnly] public CaveNodeConnectionData CaveNodeConnectionData;
+        [ReadOnly] public CaveGenComponentV2 CaveGenerator;
+
+        [SerializeField] public Line Line;
+
+        private void OnDrawGizmos()
+        {
+            if (!SelectionUtils.InSelection(this.transform)) return;
+            
+            Gizmos.color = Color.magenta;
+            var rotationFlattened = Vector3.ProjectOnPlane(this.transform.forward, Vector3.up);
+            var rotation = Quaternion.LookRotation(rotationFlattened, Vector3.up);
+                            
+            if (CaveNodeConnectionData.Source?.BoundsColliders != null)
+            {
+                foreach (var sourceBoundsCollider in CaveNodeConnectionData.Source.BoundsColliders)
+                {
+                    Gizmos.matrix = Matrix4x4.Translate(sourceBoundsCollider.bounds.center) * Matrix4x4.Rotate(rotation);
+                    Gizmos.DrawWireCube(Vector3.zero, sourceBoundsCollider.bounds.size);
+                }
+            }
+            
+            if (CaveNodeConnectionData.Target?.BoundsColliders != null)
+            {
+                foreach (var targetBoundsCollider in CaveNodeConnectionData.Target.BoundsColliders)
+                {
+                    Gizmos.matrix = Matrix4x4.Translate(targetBoundsCollider.bounds.center) * Matrix4x4.Rotate(rotation);
+                    Gizmos.DrawWireCube(Vector3.zero, targetBoundsCollider.bounds.size);
+                }
+            }
+
+            Gizmos.matrix = Matrix4x4.identity;
+        }
+    }
+}

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs.meta
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeConnectionDataMinimapComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc4e7340e2f74bc99df97fe997c5bce3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
@@ -12,6 +12,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
     {
         [ReadOnly] public CaveNodeData CaveNodeData;
         [ReadOnly] public CaveGenComponentV2 CaveGenerator;
+        [ReadOnly] public MinimapController MinimapController;
 
         [SerializeField] public ShapeRenderer OuterRenderer;
 
@@ -19,7 +20,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 
         private void Update()
         {
-            UpdatePlayerOccupied();
+            // UpdatePlayerOccupied();
         }
 
         #endregion
@@ -27,20 +28,33 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         private Color GetNodeColor(CaveNodeData caveNodeData)
         {          
             Color color;
-
-            if (caveNodeData.PlayerVisited)
+            
+            bool isInBounds = MinimapController.IsInBounds(caveNodeData.DirectPlayerDistance);
+            if (MinimapController.MinimapParameters.RestrictMapRadius && !isInBounds)
             {
-                color = CaveGenerator.MinimapParameters.VisitedColor;
+                color = MinimapController.MinimapParameters.CulledColor;
+            }
+            else if (caveNodeData.PlayerOccupied)
+            {
+                color = MinimapController.MinimapParameters.OccupiedColor;
+            }
+            else if (caveNodeData.PlayerVisited)
+            {
+                color = MinimapController.MinimapParameters.VisitedColor;
+            }
+            else if (caveNodeData.PlayerVisitedAdjacent)
+            {
+                color = MinimapController.MinimapParameters.VisibleColor;
             }
             else
             {
-                color = CaveGenerator.MinimapParameters.DefaultColor;
+                color = MinimapController.MinimapParameters.CulledColor;
             }
 
             return color;
         }
 
-        private void UpdatePlayerOccupied()
+        public void UpdatePlayerOccupied()
         {
             if (OuterRenderer != null && CaveGenerator?.MinimapParameters != null)
             {

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
@@ -63,7 +63,6 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
                     MinimapController.IsInBounds(caveNodeData.DirectPlayerDistance)
                 )
             ) {
-                Debug.Log("Outside bounds: CULL");
                 color = MinimapController.MinimapParameters.CulledColor;
                 alphaOverride = null;
             }

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BML.ScriptableObjectCore.Scripts.Variables.VariableOperators;
 using BML.Scripts.CaveV2.CaveGraph.NodeData;
 using Shapes;
 using Sirenix.OdinInspector;
@@ -14,7 +15,8 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         [ReadOnly] public CaveGenComponentV2 CaveGenerator;
         [ReadOnly] public MinimapController MinimapController;
 
-        [SerializeField] public ShapeRenderer OuterRenderer;
+        [SerializeField] public Torus UndiscoveredRenderer;
+        [FormerlySerializedAs("OuterRenderer")] [SerializeField] public Sphere DiscoveredRenderer;
 
         #region Unity lifecycle
 
@@ -25,14 +27,46 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 
         #endregion
 
+        private float initialRadius;
+        public void Initialize(CaveNodeData caveNodeData, CaveGenComponentV2 caveGenerator, MinimapController minimapController)
+        {
+            CaveNodeData = caveNodeData;
+            CaveGenerator = caveGenerator;
+            MinimapController = minimapController;
+
+            if (DiscoveredRenderer != null
+                && UndiscoveredRenderer != null)
+            {
+                initialRadius = DiscoveredRenderer.Radius;
+                UpdateRendererRadius();
+            }
+        }
+
         private Color GetNodeColor(CaveNodeData caveNodeData)
         {          
             Color color;
+            float? alphaOverride;
+            
+            float playerDistanceFac = 1f - Mathf.Clamp01((float)caveNodeData.PlayerDistance / 2f);
+            alphaOverride = (playerDistanceFac * 0.9f) + 0.1f;
             
             bool isInBounds = MinimapController.IsInBounds(caveNodeData.DirectPlayerDistance);
             if (MinimapController.MinimapParameters.RestrictMapRadius && !isInBounds)
             {
                 color = MinimapController.MinimapParameters.CulledColor;
+                alphaOverride = null;
+            }
+            else if (caveNodeData.PlayerVisited && caveNodeData == CaveGenerator.CaveGraph.StartNode)
+            {
+                color = MinimapController.MinimapParameters.Color_StartRoom;
+            }
+            else if (caveNodeData.PlayerVisited && caveNodeData == CaveGenerator.CaveGraph.EndNode)
+            {
+                color = MinimapController.MinimapParameters.Color_EndRoom;
+            }
+            else if (caveNodeData.PlayerVisited && caveNodeData == CaveGenerator.CaveGraph.MerchantNode)
+            {
+                color = MinimapController.MinimapParameters.Color_MerchantRoom;
             }
             else if (caveNodeData.PlayerOccupied)
             {
@@ -49,17 +83,48 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
             else
             {
                 color = MinimapController.MinimapParameters.CulledColor;
+                alphaOverride = null;
             }
 
-            return color;
+            Color newColor = new Color(color.r, color.g, color.b, alphaOverride ?? color.a);
+            Debug.Log($"(Player distance fac {playerDistanceFac}) (Alpha {alphaOverride}) (Color {newColor})");
+            return newColor;
+        }
+
+        private void UpdateRendererRadius()
+        {
+            if (DiscoveredRenderer != null
+                && UndiscoveredRenderer != null)
+            {
+                float relativeScale = MinimapController.MinimapParameters.GetNodeTypeRelativeScale(CaveNodeData.NodeType);
+                float radius = initialRadius * relativeScale;
+                DiscoveredRenderer.Radius = radius;
+                UndiscoveredRenderer.Radius = radius;
+            }
         }
 
         public void UpdatePlayerOccupied()
         {
-            if (OuterRenderer != null && CaveGenerator?.MinimapParameters != null)
+            if (DiscoveredRenderer != null
+                && UndiscoveredRenderer != null
+                && CaveGenerator?.MinimapParameters != null)
             {
                 Color outerColor = GetNodeColor(CaveNodeData);
-                OuterRenderer.Color = outerColor;
+                if (CaveNodeData.PlayerVisited)
+                {
+                    UndiscoveredRenderer.enabled = false;
+                    DiscoveredRenderer.enabled = true;
+                    DiscoveredRenderer.Color = outerColor;
+                }
+                else
+                {
+                    DiscoveredRenderer.enabled = false;
+                    UndiscoveredRenderer.enabled = true;
+                    UndiscoveredRenderer.Color = outerColor;
+                }
+                
+                // TODO remove from update
+                UpdateRendererRadius();
             }
         }
     }

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using BML.Scripts.CaveV2.CaveGraph.NodeData;
+using Shapes;
+using Sirenix.OdinInspector;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace BML.Scripts.CaveV2.CaveGraph.Minimap
+{
+    [ExecuteAlways]
+    public class CaveNodeDataMinimapComponent : MonoBehaviour
+    {
+        [ReadOnly] public CaveNodeData CaveNodeData;
+        [ReadOnly] public CaveGenComponentV2 CaveGenerator;
+
+        [SerializeField] public ShapeRenderer OuterRenderer;
+
+        #region Unity lifecycle
+
+        private void Update()
+        {
+            UpdatePlayerOccupied();
+        }
+
+        #endregion
+
+        private Color GetNodeColor(CaveNodeData caveNodeData)
+        {          
+            Color color;
+
+            if (caveNodeData.PlayerVisited)
+            {
+                color = CaveGenerator.MinimapParameters.VisitedColor;
+            }
+            else
+            {
+                color = CaveGenerator.MinimapParameters.DefaultColor;
+            }
+
+            return color;
+        }
+
+        private void UpdatePlayerOccupied()
+        {
+            if (OuterRenderer != null && CaveGenerator?.MinimapParameters != null)
+            {
+                Color outerColor = GetNodeColor(CaveNodeData);
+                OuterRenderer.Color = outerColor;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs.meta
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/CaveNodeDataMinimapComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51319c8964284f8386545325a03e73c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
@@ -13,15 +13,33 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         [SerializeField] private bool _readLocalRotation = false;
         [SerializeField] private bool _setLocalRotation = false;
 
+        [SerializeField] private bool _remapAngles = false;
+        [SerializeField] private Vector3 _remapAnglesMin = Vector3.zero;
+        [SerializeField] private Vector3 _remapAnglesMax = Vector3.one * 360;
+
         #endregion
 
         #region Unity lifecycle
 
         private void FixedUpdate()
         {
+            Debug.Log($"Match rotation ({name})");
             if (_target.Value != null && _transform.Value != null)
             {
                 Quaternion rotation = _readLocalRotation ? _target.Value.localRotation : _target.Value.rotation;
+                if (_remapAngles)
+                {
+                    var eulerAngles = rotation.eulerAngles;
+                    var prevEulerAngles = eulerAngles;
+                    eulerAngles.Set(
+                        Mathf.Lerp(_remapAnglesMin.x, _remapAnglesMax.x, eulerAngles.x / 360f),    
+                        Mathf.Lerp(_remapAnglesMin.y, _remapAnglesMax.y, eulerAngles.y / 360f),    
+                        Mathf.Lerp(_remapAnglesMin.z, _remapAnglesMax.z, eulerAngles.z / 360f)    
+                    );
+                    rotation.eulerAngles = eulerAngles;
+                    Debug.Log($"(Prev angles {prevEulerAngles}) (Remapped angles {eulerAngles})");
+                }
+                
                 if (_setLocalRotation)
                 {
                     _transform.Value.localRotation = rotation;

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
 using BML.Scripts.Utils;
 using UnityEngine;
@@ -13,7 +14,9 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         [SerializeField] private SafeTransformValueReference _transform;
         [SerializeField] private bool _readLocalRotation = false;
         [SerializeField] private bool _setLocalRotation = false;
+        [SerializeField] private bool _clearLocalRotationOnDisable = false;
 
+        [SerializeField] private float _maxDegreesDelta = 360f;
         [SerializeField] private bool _remapAngles = false;
         [SerializeField] private Vector3 _remapAnglesOldMin = Vector3.zero;
         [SerializeField] private Vector3 _remapAnglesOldMax = Vector3.one * 360;
@@ -24,33 +27,69 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 
         #region Unity lifecycle
 
+        private void OnDisable()
+        {
+            if (_clearLocalRotationOnDisable)
+            {
+                if (_coroutineResetRotation != null)
+                {
+                    StopCoroutine(_coroutineResetRotation);
+                }
+                
+                _coroutineResetRotation = StartCoroutine(CoroutineResetRotation());
+            }
+        }
+
         private void FixedUpdate()
         {
             if (_target.Value != null && _transform.Value != null)
             {
-                Quaternion rotation = _readLocalRotation ? _target.Value.localRotation : _target.Value.rotation;
+                Quaternion targetRotation = _readLocalRotation ? _target.Value.localRotation : _target.Value.rotation;
                 if (_remapAngles)
                 {
-                    var eulerAngles = rotation.eulerAngles;
+                    var eulerAngles = targetRotation.eulerAngles;
                     eulerAngles.Set(
                         FloatUtils.RemapRange(eulerAngles.x, _remapAnglesOldMin.x, _remapAnglesOldMax.x, _remapAnglesNewMin.x, _remapAnglesNewMax.x),    
                         FloatUtils.RemapRange(eulerAngles.y, _remapAnglesOldMin.y, _remapAnglesOldMax.y, _remapAnglesNewMin.y, _remapAnglesNewMax.y),    
                         FloatUtils.RemapRange(eulerAngles.z, _remapAnglesOldMin.z, _remapAnglesOldMax.z, _remapAnglesNewMin.z, _remapAnglesNewMax.z)    
                     );
-                    rotation.eulerAngles = eulerAngles;
+                    targetRotation.eulerAngles = eulerAngles;
                 }
-                
+
                 if (_setLocalRotation)
                 {
-                    _transform.Value.localRotation = rotation;
+                    _transform.Value.localRotation = Quaternion.RotateTowards(_transform.Value.localRotation, targetRotation, _maxDegreesDelta);
                 }
                 else
                 {
-                    _transform.Value.rotation = rotation;
+                    _transform.Value.rotation = Quaternion.RotateTowards(_transform.Value.rotation, targetRotation, _maxDegreesDelta);
                 }
             }
         }
 
         #endregion
+
+        private Coroutine _coroutineResetRotation;
+        private IEnumerator CoroutineResetRotation()
+        {
+            if (_target.Value != null && _transform.Value != null)
+            {
+                Quaternion targetRotation = Quaternion.identity;
+                Quaternion newRotation = _transform.Value.localRotation;
+                while (newRotation != targetRotation)
+                {
+                    newRotation = Quaternion.RotateTowards(
+                        _transform.Value.localRotation, 
+                        targetRotation, _maxDegreesDelta
+                    );
+                    _transform.Value.localRotation = newRotation;
+                    yield return null;
+                }
+            }
+
+            _coroutineResetRotation = null;
+
+        }
+        
     }
 }

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
+using UnityEngine;
+
+namespace BML.Scripts.CaveV2.CaveGraph.Minimap
+{
+    public class MatchRotation : MonoBehaviour
+    {
+        #region Inspector
+
+        [SerializeField] private SafeTransformValueReference _target;
+        [SerializeField] private SafeTransformValueReference _transform;
+        [SerializeField] private bool _readLocalRotation = false;
+        [SerializeField] private bool _setLocalRotation = false;
+
+        #endregion
+
+        #region Unity lifecycle
+
+        private void FixedUpdate()
+        {
+            if (_target.Value != null && _transform.Value != null)
+            {
+                Quaternion rotation = _readLocalRotation ? _target.Value.localRotation : _target.Value.rotation;
+                if (_setLocalRotation)
+                {
+                    _transform.Value.localRotation = rotation;
+                }
+                else
+                {
+                    _transform.Value.rotation = rotation;
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
+using BML.Scripts.Utils;
 using UnityEngine;
 
 namespace BML.Scripts.CaveV2.CaveGraph.Minimap
@@ -14,8 +15,10 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
         [SerializeField] private bool _setLocalRotation = false;
 
         [SerializeField] private bool _remapAngles = false;
-        [SerializeField] private Vector3 _remapAnglesMin = Vector3.zero;
-        [SerializeField] private Vector3 _remapAnglesMax = Vector3.one * 360;
+        [SerializeField] private Vector3 _remapAnglesOldMin = Vector3.zero;
+        [SerializeField] private Vector3 _remapAnglesOldMax = Vector3.one * 360;
+        [SerializeField] private Vector3 _remapAnglesNewMin = Vector3.zero;
+        [SerializeField] private Vector3 _remapAnglesNewMax = Vector3.one * 360;
 
         #endregion
 
@@ -23,21 +26,18 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 
         private void FixedUpdate()
         {
-            Debug.Log($"Match rotation ({name})");
             if (_target.Value != null && _transform.Value != null)
             {
                 Quaternion rotation = _readLocalRotation ? _target.Value.localRotation : _target.Value.rotation;
                 if (_remapAngles)
                 {
                     var eulerAngles = rotation.eulerAngles;
-                    var prevEulerAngles = eulerAngles;
                     eulerAngles.Set(
-                        Mathf.Lerp(_remapAnglesMin.x, _remapAnglesMax.x, eulerAngles.x / 360f),    
-                        Mathf.Lerp(_remapAnglesMin.y, _remapAnglesMax.y, eulerAngles.y / 360f),    
-                        Mathf.Lerp(_remapAnglesMin.z, _remapAnglesMax.z, eulerAngles.z / 360f)    
+                        FloatUtils.RemapRange(eulerAngles.x, _remapAnglesOldMin.x, _remapAnglesOldMax.x, _remapAnglesNewMin.x, _remapAnglesNewMax.x),    
+                        FloatUtils.RemapRange(eulerAngles.y, _remapAnglesOldMin.y, _remapAnglesOldMax.y, _remapAnglesNewMin.y, _remapAnglesNewMax.y),    
+                        FloatUtils.RemapRange(eulerAngles.z, _remapAnglesOldMin.z, _remapAnglesOldMax.z, _remapAnglesNewMin.z, _remapAnglesNewMax.z)    
                     );
                     rotation.eulerAngles = eulerAngles;
-                    Debug.Log($"(Prev angles {prevEulerAngles}) (Remapped angles {eulerAngles})");
                 }
                 
                 if (_setLocalRotation)

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs
@@ -35,8 +35,12 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
                 {
                     StopCoroutine(_coroutineResetRotation);
                 }
+
+                if (ApplicationUtils.IsPlaying_EditorSafe)
+                {
+                    _coroutineResetRotation = StartCoroutine(CoroutineResetRotation());
+                }
                 
-                _coroutineResetRotation = StartCoroutine(CoroutineResetRotation());
             }
         }
 

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs.meta
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MatchRotation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 83a28b539cad4ce0a0107cafc58c739c
+timeCreated: 1678218715

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MinimapController.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MinimapController.cs
@@ -9,18 +9,20 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
     {
         #region Inspector
 
+        [SerializeField] public CaveMinimapParameters MinimapParameters;
 
         [SerializeField] private bool _doCenterOnPlayer = true;
         [SerializeField] private SafeTransformValueReference _levelRoot;
         [SerializeField] private SafeTransformValueReference _playerPosition;
 
-        [SerializeField] private SafeFloatValueReference _zoomLevel;
-        private float _zoomBaseline = 0.006f;
-        
         [SerializeField] private Transform _translationTarget;
         [SerializeField] private Transform _scalingTarget;
 
+        [SerializeField] private SphereCollider _cullOutside;
+
         #endregion
+
+        public float _zoomBaseline = 0.006f;
 
         #region Unity lifecycle
 
@@ -42,11 +44,32 @@ namespace BML.Scripts.CaveV2.CaveGraph.Minimap
 
             if (_scalingTarget != null)
             {
-                float scale = _zoomBaseline * _zoomLevel.Value;
+                float scale = _zoomBaseline * MinimapParameters.ZoomLevel.Value;
                 Vector3 localScale = _scalingTarget.localScale;
                 localScale.Set(scale, scale, scale);
                 _scalingTarget.localScale = localScale;
             }
+        }
+
+        #endregion
+
+        #region Public interface
+
+        public (bool inBounds, Vector3 closestPoint) IsInBounds(Vector3 v)
+        {
+            if (_cullOutside == null) return (true, v);
+                
+            Vector3 closestPoint = _cullOutside.ClosestPoint(v);
+            bool inBounds = (v == closestPoint);
+            return (inBounds, closestPoint);
+        }
+        
+        public bool IsInBounds(float directPlayerDistance)
+        {
+            if (_cullOutside == null) return true;
+
+            bool inBounds = (directPlayerDistance <= MinimapParameters.MapPlayerRadius);
+            return inBounds;
         }
 
         #endregion

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MinimapController.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MinimapController.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using BML.ScriptableObjectCore.Scripts.SceneReferences;
+using BML.ScriptableObjectCore.Scripts.Variables.SafeValueReferences;
+using UnityEngine;
+
+namespace BML.Scripts.CaveV2.CaveGraph.Minimap
+{
+    public class MinimapController : MonoBehaviour
+    {
+        #region Inspector
+
+
+        [SerializeField] private bool _doCenterOnPlayer = true;
+        [SerializeField] private SafeTransformValueReference _levelRoot;
+        [SerializeField] private SafeTransformValueReference _playerPosition;
+
+        [SerializeField] private SafeFloatValueReference _zoomLevel;
+        private float _zoomBaseline = 0.006f;
+        
+        [SerializeField] private Transform _translationTarget;
+        [SerializeField] private Transform _scalingTarget;
+
+        #endregion
+
+        #region Unity lifecycle
+
+        private void Awake()
+        {
+            if (_scalingTarget != null)
+            {
+                _zoomBaseline = _scalingTarget.localScale.x;
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            if (_doCenterOnPlayer && _translationTarget != null && _levelRoot?.Value != null && _playerPosition?.Value != null)
+            {
+                Vector3 relativePosition = (_playerPosition.Value.position - _levelRoot.Value.position);
+                _translationTarget.localPosition = -relativePosition;
+            }
+
+            if (_scalingTarget != null)
+            {
+                float scale = _zoomBaseline * _zoomLevel.Value;
+                Vector3 localScale = _scalingTarget.localScale;
+                localScale.Set(scale, scale, scale);
+                _scalingTarget.localScale = localScale;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MinimapController.cs.meta
+++ b/Assets/Scripts/CaveV2/CaveGraph/MiniMap/MinimapController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b16b260343dd417aabd2e467dbfa0901
+timeCreated: 1678208783

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeConnectionData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeConnectionData.cs
@@ -48,6 +48,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             }
         }
         [ShowInInspector] public bool PlayerVisitedAdjacent { get; set; }
+        [ShowInInspector] public bool PlayerVisitedAllAdjacent { get; set; }
         [ShowInInspector] public bool PlayerOccupied { get; set; }
         [ShowInInspector] public int TorchRequirement { get; set; }
         [ShowInInspector] public float TorchInfluence { get; set; }
@@ -95,6 +96,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
 
             PlayerVisited = false;
             PlayerVisitedAdjacent = false;
+            PlayerVisitedAllAdjacent = false;
             PlayerOccupied = false;
             TorchRequirement = CaveNodeDataUtils.TorchRequirementMinMax.x;
             TorchInfluence = -1f;

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeConnectionData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeConnectionData.cs
@@ -32,6 +32,8 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             => Mathf.Min(Source.PlayerDistance, Target.PlayerDistance);
         [ShowInInspector] public int PlayerDistanceDelta
             => Mathf.RoundToInt((Source.PlayerDistanceDelta + Target.PlayerDistanceDelta) / 2f);
+        [ShowInInspector] public float DirectPlayerDistance
+            => Mathf.Min(Source.DirectPlayerDistance, Target.DirectPlayerDistance);
         
         [ShowInInspector] 
         public bool PlayerVisited
@@ -45,6 +47,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
                 playerVisited = value;
             }
         }
+        [ShowInInspector] public bool PlayerVisitedAdjacent { get; set; }
         [ShowInInspector] public bool PlayerOccupied { get; set; }
         [ShowInInspector] public int TorchRequirement { get; set; }
         [ShowInInspector] public float TorchInfluence { get; set; }
@@ -91,6 +94,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             SteepnessAngle = Mathf.Rad2Deg * Mathf.Atan2(verticalComponent, horizontalComponent);
 
             PlayerVisited = false;
+            PlayerVisitedAdjacent = false;
             PlayerOccupied = false;
             TorchRequirement = CaveNodeDataUtils.TorchRequirementMinMax.x;
             TorchInfluence = -1f;

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeData.cs
@@ -38,6 +38,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             }
         }
         [ShowInInspector] public bool PlayerVisitedAdjacent { get; set; }
+        [ShowInInspector] public bool PlayerVisitedAllAdjacent { get; set; }
         [ShowInInspector] public bool PlayerOccupied { get; set; }
         [ShowInInspector] public int TorchRequirement { get; set; }
         [ShowInInspector] public float TorchInfluence { get; set; }
@@ -81,6 +82,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             DirectPlayerDistance = -1;
             PlayerVisited = false;
             PlayerVisitedAdjacent = false;
+            PlayerVisitedAllAdjacent = false;
             PlayerOccupied = false;
             TorchRequirement = CaveNodeDataUtils.TorchRequirementMinMax.x;
             TorchInfluence = -1f;

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeData.cs
@@ -23,7 +23,8 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
         [ShowInInspector] public int ObjectiveDistance { get; set; }
         [ShowInInspector] public int PlayerDistance { get; set; }
         [ShowInInspector] public int PlayerDistanceDelta { get; set; }
-
+        [ShowInInspector] public float DirectPlayerDistance { get; set; }
+        
         [ShowInInspector]
         public bool PlayerVisited
         {
@@ -36,6 +37,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
                 playerVisited = value;
             }
         }
+        [ShowInInspector] public bool PlayerVisitedAdjacent { get; set; }
         [ShowInInspector] public bool PlayerOccupied { get; set; }
         [ShowInInspector] public int TorchRequirement { get; set; }
         [ShowInInspector] public float TorchInfluence { get; set; }
@@ -76,7 +78,9 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             ObjectiveDistance = -1;
             PlayerDistance = -1;
             PlayerDistanceDelta = 0;
+            DirectPlayerDistance = -1;
             PlayerVisited = false;
+            PlayerVisitedAdjacent = false;
             PlayerOccupied = false;
             TorchRequirement = CaveNodeDataUtils.TorchRequirementMinMax.x;
             TorchInfluence = -1f;

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/ICaveNodeData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/ICaveNodeData.cs
@@ -18,6 +18,7 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
         [ShowInInspector] public float DirectPlayerDistance { get; }
         [ShowInInspector] public bool PlayerVisited { get; set; }
         [ShowInInspector] public bool PlayerVisitedAdjacent { get; set; }
+        [ShowInInspector] public bool PlayerVisitedAllAdjacent { get; set; }
         [ShowInInspector] public bool PlayerOccupied { get; set; }
         [ShowInInspector] public int TorchRequirement { get; set; }
         [ShowInInspector] public float TorchInfluence { get; set; }

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/ICaveNodeData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/ICaveNodeData.cs
@@ -15,7 +15,9 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
         [ShowInInspector] public int ObjectiveDistance { get; }
         [ShowInInspector] public int PlayerDistance { get; }
         [ShowInInspector] public int PlayerDistanceDelta { get; }
+        [ShowInInspector] public float DirectPlayerDistance { get; }
         [ShowInInspector] public bool PlayerVisited { get; set; }
+        [ShowInInspector] public bool PlayerVisitedAdjacent { get; set; }
         [ShowInInspector] public bool PlayerOccupied { get; set; }
         [ShowInInspector] public int TorchRequirement { get; set; }
         [ShowInInspector] public float TorchInfluence { get; set; }

--- a/Assets/Scripts/CaveV2/PlayerInfluenceUpdater.cs
+++ b/Assets/Scripts/CaveV2/PlayerInfluenceUpdater.cs
@@ -76,7 +76,9 @@ namespace BML.Scripts.CaveV2
                         foreach (var caveNodeConnectionData in _caveGenerator.CaveGraph.AdjacentEdges(caveNodeData))
                         {
                             caveNodeConnectionData.PlayerVisitedAdjacent = true;
+                            UpdatePlayerVisitedAllAdjacent(caveNodeConnectionData);
                         }
+                        UpdatePlayerVisitedAllAdjacent(caveNodeData);
                         caveNodeData.PlayerOccupied = true;
                         _influenceState._currentNodes.Add(other, caveNodeData);
                         _caveGenerator?.UpdatePlayerDistance(_influenceState._currentNodes.Values.AsEnumerable());
@@ -104,6 +106,9 @@ namespace BML.Scripts.CaveV2
                         caveNodeConnectionData.Source.PlayerVisitedAdjacent = true;
                         caveNodeConnectionData.Target.PlayerVisitedAdjacent = true;
                         caveNodeConnectionData.PlayerOccupied = true;
+                        UpdatePlayerVisitedAllAdjacent(caveNodeConnectionData);
+                        UpdatePlayerVisitedAllAdjacent(caveNodeConnectionData.Source);
+                        UpdatePlayerVisitedAllAdjacent(caveNodeConnectionData.Target);
                         _influenceState._currentNodeConnections.Add(other, caveNodeConnectionData);
                         // _caveGenerator?.UpdatePlayerDistance(_currentNodes.Values.AsEnumerable());
                         
@@ -152,6 +157,21 @@ namespace BML.Scripts.CaveV2
         private void UpdatePlayerDistanceToCurrent()
         {
             _caveGenerator?.UpdatePlayerDistance(_influenceState._currentNodes.Values.AsEnumerable());
+        }
+
+        private bool UpdatePlayerVisitedAllAdjacent(CaveNodeData caveNodeData)
+        {
+            var adjacentEdges = _caveGenerator.CaveGraph.AdjacentEdges(caveNodeData);
+            bool playerVisitedAllAdjacent = adjacentEdges.All(e => e.PlayerVisited);
+            caveNodeData.PlayerVisitedAllAdjacent = playerVisitedAllAdjacent;
+            return playerVisitedAllAdjacent;
+        }
+        
+        private bool UpdatePlayerVisitedAllAdjacent(CaveNodeConnectionData caveNodeConnectionData)
+        {
+            bool playerVisitedAllAdjacent = caveNodeConnectionData.Source.PlayerVisited && caveNodeConnectionData.Target.PlayerVisited;
+            caveNodeConnectionData.PlayerVisitedAllAdjacent = playerVisitedAllAdjacent;
+            return playerVisitedAllAdjacent;
         }
     }
 }

--- a/Assets/Scripts/CaveV2/PlayerInfluenceUpdater.cs
+++ b/Assets/Scripts/CaveV2/PlayerInfluenceUpdater.cs
@@ -45,10 +45,10 @@ namespace BML.Scripts.CaveV2
             {
                 if (_enableLogs) Debug.Log($"PlayerInfluenceUpdater OnTriggerEnter");
                     
-                bool isAlreadyEntered =
+                bool isNotAlreadyEntered =
                     (!_influenceState._currentNodes.ContainsKey(other) &&
                      !_influenceState._currentNodeConnections.ContainsKey(other));
-                if (isAlreadyEntered)
+                if (isNotAlreadyEntered)
                 {
                     var caveNodeDataComponent = other.GetComponentInParent<CaveNodeDataDebugComponent>();
                     if (caveNodeDataComponent != null)
@@ -73,6 +73,10 @@ namespace BML.Scripts.CaveV2
                         // }
                         
                         caveNodeData.PlayerVisited = true;
+                        foreach (var caveNodeConnectionData in _caveGenerator.CaveGraph.AdjacentEdges(caveNodeData))
+                        {
+                            caveNodeConnectionData.PlayerVisitedAdjacent = true;
+                        }
                         caveNodeData.PlayerOccupied = true;
                         _influenceState._currentNodes.Add(other, caveNodeData);
                         _caveGenerator?.UpdatePlayerDistance(_influenceState._currentNodes.Values.AsEnumerable());
@@ -97,6 +101,8 @@ namespace BML.Scripts.CaveV2
                         }
                         
                         caveNodeConnectionData.PlayerVisited = true;
+                        caveNodeConnectionData.Source.PlayerVisitedAdjacent = true;
+                        caveNodeConnectionData.Target.PlayerVisitedAdjacent = true;
                         caveNodeConnectionData.PlayerOccupied = true;
                         _influenceState._currentNodeConnections.Add(other, caveNodeConnectionData);
                         // _caveGenerator?.UpdatePlayerDistance(_currentNodes.Values.AsEnumerable());

--- a/Assets/Scripts/Player/PlayerInputProcessor.cs
+++ b/Assets/Scripts/Player/PlayerInputProcessor.cs
@@ -83,6 +83,7 @@ namespace BML.Scripts.Player
 
 		[SerializeField] private BoolVariable _isUsingUi_Out_Any;
 		[SerializeField] private BoolVariable _isUsingUi_Out_HidePlayerHUD;
+		[SerializeField] private BoolVariable _isUsingUi_Out_InteractableOverlay;
 		
 		private InputAction jumpAction;
 		private InputAction crouchAction;
@@ -494,7 +495,7 @@ namespace BML.Scripts.Player
 			else if (IsUsingUi_InteractableOverlay)
 			{
 				SwitchCurrentActionMap(playerInput, true, "Debug_FKeys", "Debug_Extended", "UI", "UI_Player");
-				SetCursorState(false);
+				SetCursorState(false, !_isMinimapOpen.Value);
 			}
 			else
 			{
@@ -504,13 +505,20 @@ namespace BML.Scripts.Player
 
 			_isUsingUi_Out_Any.Value = IsUsingUi;
 			_isUsingUi_Out_HidePlayerHUD.Value = IsUsingUi_HidePlayerHUD;
+			_isUsingUi_Out_InteractableOverlay.Value = IsUsingUi_InteractableOverlay;
 			
 			if (_enableLogs) Debug.Log($"ApplyInputState Inputs (NoPlayerControl {IsUsingUi_NoPlayerControl}) (InteractableOverlay {IsUsingUi_InteractableOverlay}) => updated input state to: (ActionMap {playerInput.currentActionMap.name}) (CursorLocked {Cursor.lockState})");
 		}
 		
-		private void SetCursorState(bool newState)
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="newState"></param>
+		/// <param name="visible">Even when 'true', the cursor will not be visible when it is locked.</param>
+		private void SetCursorState(bool newState, bool visible = true)
 		{
 			Cursor.lockState = newState ? CursorLockMode.Locked : CursorLockMode.None;
+			Cursor.visible = visible;
 		}
 	}
 	

--- a/Assets/Scripts/Player/PlayerInputProcessor.cs
+++ b/Assets/Scripts/Player/PlayerInputProcessor.cs
@@ -37,6 +37,7 @@ namespace BML.Scripts.Player
 		[SerializeField] private Vector2Reference _mouseInput;
 		[SerializeField] private Vector2Reference _moveInput;
 		[SerializeField] private BoolReference _isPaused;
+		[SerializeField] private BoolReference _isMinimapOpen;
 		[SerializeField] private BoolReference _isStoreOpen;
 		[SerializeField] private BoolReference _isUpgradeStoreOpen;
 		[SerializeField] private GameEvent _onStoreFailOpen;
@@ -257,6 +258,35 @@ namespace BML.Scripts.Player
 			// SetCursorState(false);
 		}
 
+		public void OnToggleMinimap()
+		{
+			// Do nothing if blocking menu is already open
+			if (!_isMinimapOpen.Value && IsUsingUi_Blocking)
+			{
+				return;
+			}
+			
+			// Play feedback if store fails to open due to combat
+			// if (!_isStoreOpen.Value && _isPlayerInCombat.Value)
+			// {
+			// 	_onStoreFailOpen.Raise();
+			// 	return;
+			// }
+
+			if (!_isMinimapOpen.Value)
+			{
+				foreach (var menuStateBoolVariable in _containerUiMenuStates_NonBlocking.GetBoolVariables())
+				{
+					if (!menuStateBoolVariable.Equals(_isMinimapOpen))
+					{
+						menuStateBoolVariable.Value = false;
+					}
+				}
+			}
+
+			_isMinimapOpen.Value = !_isMinimapOpen.Value;
+		}
+
 		public void OnToggleStore()
 		{
 			// Do nothing if blocking menu is already open
@@ -272,13 +302,17 @@ namespace BML.Scripts.Player
 				return;
 			}
 
-            if(!_isStoreOpen.Value) {
-                _containerUiMenuStates_NonBlocking.GetBoolVariables().ForEach((menuState) => {
-                    if(!menuState.Equals(_isStoreOpen)) {
-                        menuState.Value = false;
-                    }
-                });
-            }
+			// If opening the store, close other menus
+			if (!_isStoreOpen.Value)
+			{
+				foreach (var menuStateBoolVariable in _containerUiMenuStates_NonBlocking.GetBoolVariables())
+				{
+					if (!menuStateBoolVariable.Equals(_isStoreOpen))
+					{
+						menuStateBoolVariable.Value = false;
+					}
+				}
+			}
 
 			_isStoreOpen.Value = !_isStoreOpen.Value;
 		}
@@ -302,13 +336,16 @@ namespace BML.Scripts.Player
                 return;
             }
 
-            //if going to open store, close other menus
-            if(!_isUpgradeStoreOpen.Value) {
-                _containerUiMenuStates_NonBlocking.GetBoolVariables().ForEach((menuState) => {
-                    if(!menuState.Equals(_isUpgradeStoreOpen)) {
-                        menuState.Value = false;
-                    }
-                });
+            // If opening the store, close other menus
+            if (!_isUpgradeStoreOpen.Value)
+            {
+	            foreach (var menuStateBoolVariable in _containerUiMenuStates_NonBlocking.GetBoolVariables())
+	            {
+		            if (!menuStateBoolVariable.Equals(_isUpgradeStoreOpen))
+		            {
+			            menuStateBoolVariable.Value = false;
+		            }
+	            }
             }
 
 			_isUpgradeStoreOpen.Value = !_isUpgradeStoreOpen.Value;

--- a/Assets/Scripts/Utils/FloatUtils.cs
+++ b/Assets/Scripts/Utils/FloatUtils.cs
@@ -8,5 +8,14 @@ namespace BML.Scripts.Utils
         {
             return Mathf.Abs(val) < 0.001f ? 0 : val;
         }
+
+        public static float RemapRange(float value, float oldMin, float oldMax, float newMin, float newMax)
+        {
+            float oldRange = (oldMax - oldMin);
+            float pct = Mathf.Approximately(oldRange, 0) 
+                ? 0 : (value - oldMin) / oldRange;
+            float newValue = pct * (newMax - newMin) + newMin;
+            return newValue;
+        }
     }
 }

--- a/Assets/UI/HUD_Minimap.prefab
+++ b/Assets/UI/HUD_Minimap.prefab
@@ -1,0 +1,664 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4400192675207510267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 42553019519055221}
+  - component: {fileID: 6186741887206576535}
+  - component: {fileID: 1060984789984500404}
+  - component: {fileID: 4654756336746696374}
+  m_Layer: 0
+  m_Name: Canvas_Minimap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &42553019519055221
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4400192675207510267}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8247903319141760433}
+  m_Father: {fileID: 5413178696439222470}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &6186741887206576535
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4400192675207510267}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1060984789984500404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4400192675207510267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &4654756336746696374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4400192675207510267}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 0
+--- !u!1 &5413178696439222471
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5413178696439222470}
+  - component: {fileID: 2791431147006285193}
+  m_Layer: 0
+  m_Name: HUD_Minimap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5413178696439222470
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5413178696439222471}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8863445843269742332}
+  - {fileID: 42553019519055221}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2791431147006285193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5413178696439222471}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6dc48c641bb39742af066b7a0250f33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_note: 'The actual minimap is implemented using meshes (Shapes asset), attached
+    to the main camera on the Player prefab.
+
+    This canvas just exists for the
+    UI control portions of the minimap: currently the only function is capturing
+    clicking anywhere on the screen to close the map.'
+--- !u!1 &7352251905885251730
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8863445843269742332}
+  - component: {fileID: 846017374415732620}
+  - component: {fileID: 2514105861848173016}
+  - component: {fileID: 7037391529404539433}
+  m_Layer: 0
+  m_Name: CanvasController_PlayerHealth
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8863445843269742332
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7352251905885251730}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5413178696439222470}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &846017374415732620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7352251905885251730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bcc561d61138de47bdb32d717cd44c0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  UnityEvents:
+  - UnityCallback: 1
+    randomDelay: 0
+    delay: 0
+    delayMin: 0
+    delayMax: 0
+    unityEvent:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 7037391529404539433}
+          m_TargetAssemblyTypeName: BML.VisualStateMachine.Scripts.Events.ConditionalEvent,
+            StateMachine
+          m_MethodName: TryRaise
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+--- !u!114 &2514105861848173016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7352251905885251730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bac3452c3d166594f8e8494b57ab1162, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  BoolVariables:
+  - {fileID: 11400000, guid: 78096da5c2f101d45a1fe35e8477cd52, type: 2}
+  FloatVariables: []
+  IntVariables: []
+  Vector2Variables: []
+  Vector3Variables: []
+  OnIncrease:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7037391529404539433}
+        m_TargetAssemblyTypeName: BML.VisualStateMachine.Scripts.Events.ConditionalEvent,
+          StateMachine
+        m_MethodName: TryRaise
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  OnDecrease:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7037391529404539433}
+        m_TargetAssemblyTypeName: BML.VisualStateMachine.Scripts.Events.ConditionalEvent,
+          StateMachine
+        m_MethodName: TryRaise
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &7037391529404539433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7352251905885251730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07d9de05a2e70424e8718c7cf216b134, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  conditionPreview: '-  Game_ Menu Is Open_ Minimap
+
+'
+  StateMachines: []
+  ValidStates: []
+  InvalidStates: []
+  BoolConditions:
+  - targetParameter:
+      UseConstant: 0
+      EnableInstanceOptions: 0
+      InstanceName: 
+      InstancePath: IntermediateProperties
+      ConstantValue: 0
+      Variable: {fileID: 11400000, guid: 78096da5c2f101d45a1fe35e8477cd52, type: 2}
+    value:
+      UseConstant: 1
+      EnableInstanceOptions: 0
+      InstanceName: 
+      InstancePath: IntermediateProperties
+      ConstantValue: 1
+      Variable: {fileID: 0}
+  FloatConditions: []
+  IntConditions: []
+  TimerConditions: []
+  Vector2Conditions: []
+  Vector3Conditions: []
+  GameEventConditions: []
+  DynamicGameEventConditions: []
+  OnSuccess:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4400192675207510267}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+  OnFailure:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4400192675207510267}
+        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+        m_MethodName: SetActive
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1001 &6081490217043970243
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 42553019519055221}
+    m_Modifications:
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 11400000, guid: 78096da5c2f101d45a1fe35e8477cd52, type: 2}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 3730306246979474969}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetValue
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: PlayFeedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: BML.ScriptableObjectCore.Scripts.Variables.Variable`1[[System.Boolean,
+        mscorlib
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 15007832903943939, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943153, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_Name
+      value: UiMenuScreenBackground
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+--- !u!1 &8247903319141760434 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2743742752349943153, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+  m_PrefabInstance: {fileID: 6081490217043970243}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &8247903319141760433 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2743742752349943154, guid: b0e34c8b52f23d045ad369fa4945c569, type: 3}
+  m_PrefabInstance: {fileID: 6081490217043970243}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3730306246979474969
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8247903319141760434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Feedbacks: []
+  InitializationMode: 2
+  SafeMode: 3
+  Direction: 0
+  AutoChangeDirectionOnEnd: 0
+  AutoPlayOnStart: 0
+  AutoPlayOnEnable: 0
+  ForceTimescaleMode: 0
+  ForcedTimescaleMode: 1
+  DurationMultiplier: 1
+  RandomizeDuration: 0
+  RandomDurationMultiplier: {x: 0.5, y: 1.5}
+  DisplayFullDurationDetails: 0
+  PlayerTimescaleMode: 1
+  OnlyPlayIfWithinRange: 0
+  RangeCenter: {fileID: 0}
+  RangeDistance: 5
+  UseRangeFalloff: 0
+  RangeFalloff:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  RemapRangeFalloff: {x: 0, y: 1}
+  IgnoreRangeEvents: 0
+  CooldownDuration: 0
+  InitialDelay: 0
+  CanPlay: 1
+  CanPlayWhileAlreadyPlaying: 1
+  ChanceToPlay: 100
+  FeedbacksIntensity: 1
+  Events:
+    TriggerMMFeedbacksEvents: 0
+    TriggerUnityEvents: 1
+    OnPlay:
+      m_PersistentCalls:
+        m_Calls: []
+    OnPause:
+      m_PersistentCalls:
+        m_Calls: []
+    OnResume:
+      m_PersistentCalls:
+        m_Calls: []
+    OnRevert:
+      m_PersistentCalls:
+        m_Calls: []
+    OnComplete:
+      m_PersistentCalls:
+        m_Calls: []
+  DebugActive: 0
+  FeedbacksList:
+  - id: 0
+  KeepPlayModeChanges: 0
+  PerformanceMode: 0
+  ForceStopFeedbacksOnDisable: 1
+  references:
+    version: 1
+    00000000:
+      type: {class: MMF_DebugLog, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks.MMTools}
+      data:
+        Active: 1
+        UniqueID: -80941043
+        Label: Log
+        ChannelMode: 0
+        Channel: 0
+        MMChannelDefinition: {fileID: 0}
+        Chance: 100
+        DisplayColor: {r: 0, g: 0, b: 0, a: 1}
+        Timing:
+          TimescaleMode: 0
+          ExcludeFromHoldingPauses: 0
+          ContributeToTotalDuration: 1
+          InitialDelay: 0
+          CooldownDuration: 0
+          InterruptsOnStop: 1
+          NumberOfRepeats: 0
+          RepeatForever: 0
+          DelayBetweenRepeats: 1
+          MMFeedbacksDirectionCondition: 0
+          PlayDirection: 0
+          ConstantIntensity: 0
+          UseIntensityInterval: 0
+          IntensityIntervalMin: 0
+          IntensityIntervalMax: 0
+          Sequence: {fileID: 0}
+          TrackID: 0
+          Quantized: 0
+          TargetBPM: 120
+        AutomatedTargetAcquisition:
+          Mode: 0
+          ChildIndex: 0
+        RandomizeOutput: 0
+        RandomMultiplier: {x: 0.8, y: 1}
+        RandomizeDuration: 0
+        RandomDurationMultiplier: {x: 0.5, y: 2}
+        UseRange: 0
+        RangeDistance: 5
+        UseRangeFalloff: 0
+        RangeFalloff:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 0
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        RemapRangeFalloff: {x: 0, y: 1}
+        Owner: {fileID: 3730306246979474969}
+        DebugActive: 0
+        DebugLogMode: 0
+        DebugMessage: 'Clicked Background
+
+'
+        DebugColor: {r: 0, g: 1, b: 1, a: 1}
+        DisplayFrameCount: 1

--- a/Assets/UI/HUD_Minimap.prefab.meta
+++ b/Assets/UI/HUD_Minimap.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 601db8ec67f70c446b3afeb1c81521a1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Implement "rotation only" targetting mode in the PID controllers.
- Add SafeTransformValueReference
- Initial version of 3D minimap.
- Add minimap controller: centers map on the player, and adds zoom control.
- Add player location indicator.
- Implement DirectPlayerDistance and PlayerVisitedAdjacent for cave nodes; use those metrics to implement minimap culling and room "visibility". Update minimap only when player changes rooms.
- Remap rotation angles to lock minimap to top-down view.
- Update minimap colors.
- Add counter-rotation based on the camera angle to keep the minimap always in top-down view.
- Reposition minimap and compass.
- Add ICaveNodeData metric for PlayerVisitedAllAdjacent.
- Implement minimap opacity based on player distance. Distinguish unvisited paths/rooms as dashed/outlined. Mark start, end, and merchant with different colors.
- Add button to transition minimap to fullscreen, with full 3D rotation.
- Remove log.
- Fix null minimap check.
- Fix compass target position.
- Only start coroutine if game is playing.
- Fix player arrow always on top.
- Actually fix player always on top.
- When minimap overlay is open: move player held items (like "open store" feedback), hide cursor, and click to close.
- Disable the compass.
- Rebind minimap to 'M'.
