### PR TITLE
Dev/enemy spawning

### DIFF
--- a/Assets/Entities/CaveGen/MudBun/Rooms/MudBrushGroup_Room_Large_Base.prefab
+++ b/Assets/Entities/CaveGen/MudBun/Rooms/MudBrushGroup_Room_Large_Base.prefab
@@ -635,6 +635,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: '{Spawn_Enemy_Zombie}'
       objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _spawnLimit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _ignoreGlobalSpawnCap
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _guaranteeSpawnIfInRange
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _applySpawnLimitOnlyToGuaranteedSpawns
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
 --- !u!4 &2566699112358844782 stripped
@@ -696,6 +716,18 @@ PrefabInstance:
     - target: {fileID: 3656076094256277583, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
       propertyPath: m_Name
       value: '{Spawn_Enemy_Bat} (1)'
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
+      propertyPath: _ignoreGlobalSpawnCap
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
+      propertyPath: _guaranteeSpawnIfInRange
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
+      propertyPath: OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
@@ -945,6 +977,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: '{Spawn_Enemy_Zombie} (1)'
       objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _spawnLimit
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _ignoreGlobalSpawnCap
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _guaranteeSpawnIfInRange
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: _applySpawnLimitOnlyToGuaranteedSpawns
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
+      propertyPath: OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4da20265f558b2c4ba7f7a4e22edd9aa, type: 3}
 --- !u!4 &7670746230250734428 stripped
@@ -1006,6 +1058,18 @@ PrefabInstance:
     - target: {fileID: 3656076094256277583, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
       propertyPath: m_Name
       value: '{Spawn_Enemy_Bat}'
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
+      propertyPath: _ignoreGlobalSpawnCap
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
+      propertyPath: _guaranteeSpawnIfInRange
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596033602965063984, guid: 305cd963743536e419e94ed92ad89a52, type: 3}
+      propertyPath: OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 305cd963743536e419e94ed92ad89a52, type: 3}

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   _limitToOneSpawnAtATime: 1
   _spawnLimit: 1
   _applySpawnLimitOnlyToGuaranteedSpawns: 0
-  IgnoreGlobalSpawnCap: 0
+  IgnoreGlobalSpawnCap: 1
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
@@ -52,7 +52,7 @@ MonoBehaviour:
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
   _doInheritParentRotation: 1
-  _rotateTowardsSurfaceNormal: 1
+  _rotateTowardsSurfaceNormal: 0
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 1
@@ -61,7 +61,8 @@ MonoBehaviour:
   _limitToOneSpawnAtATime: 1
   _spawnLimit: 1
   _applySpawnLimitOnlyToGuaranteedSpawns: 0
-  IgnoreGlobalSpawnCap: 1
+  _ignoreGlobalSpawnCap: 1
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
@@ -56,13 +56,13 @@ MonoBehaviour:
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 1
-  _persistSpawns: 0
-  _guaranteeSpawnIfInRange: 1
+  _persistSpawns: 1
+  _guaranteeSpawnIfInRange: 0
   _limitToOneSpawnAtATime: 1
   _spawnLimit: 1
   _applySpawnLimitOnlyToGuaranteedSpawns: 0
-  _ignoreGlobalSpawnCap: 1
-  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 0
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
@@ -51,8 +51,19 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: 1, z: 0}
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
+  _doInheritParentRotation: 1
+  _rotateTowardsSurfaceNormal: 1
+  _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 1
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 1
+  _limitToOneSpawnAtATime: 1
+  _spawnLimit: 1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  IgnoreGlobalSpawnCap: 0
+  _showDebugPrefab: 0
+  _debugPrefab: {fileID: 0}
   Occupied: 0
 --- !u!135 &2234711870761473012
 SphereCollider:

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Sentinel}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Sentinel}.prefab
@@ -50,6 +50,18 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: -1, z: 0}
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
+  _doInheritParentRotation: 1
+  _rotateTowardsSurfaceNormal: 1
+  _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 1
+  _limitToOneSpawnAtATime: 1
+  _spawnLimit: 1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 1
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _showDebugPrefab: 0
+  _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
@@ -61,7 +61,7 @@ MonoBehaviour:
   _limitToOneSpawnAtATime: 1
   _spawnLimit: 1
   _applySpawnLimitOnlyToGuaranteedSpawns: 1
-  IgnoreGlobalSpawnCap: 0
+  IgnoreGlobalSpawnCap: 1
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
@@ -57,11 +57,12 @@ MonoBehaviour:
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
   _persistSpawns: 0
-  _guaranteeSpawnIfInRange: 1
+  _guaranteeSpawnIfInRange: 0
   _limitToOneSpawnAtATime: 1
-  _spawnLimit: 1
-  _applySpawnLimitOnlyToGuaranteedSpawns: 1
-  IgnoreGlobalSpawnCap: 1
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 0
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
@@ -51,8 +51,19 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: -1, z: 0}
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
+  _doInheritParentRotation: 1
+  _rotateTowardsSurfaceNormal: 1
+  _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 1
+  _limitToOneSpawnAtATime: 1
+  _spawnLimit: 1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 1
+  IgnoreGlobalSpawnCap: 0
+  _showDebugPrefab: 0
+  _debugPrefab: {fileID: 0}
   Occupied: 0
 --- !u!135 &2234711870761473012
 SphereCollider:

--- a/Assets/Entities/Enemy/BatEnemy/BatEnemy.prefab
+++ b/Assets/Entities/Enemy/BatEnemy/BatEnemy.prefab
@@ -12021,24 +12021,40 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
-      value: 1
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Mode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Mode
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 5301634461988987545}
+      objectReference: {fileID: 6703844820478198895}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
-      objectReference: {fileID: 4636399703202130992}
+      objectReference: {fileID: 5301634461988987545}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Target
       value: 
-      objectReference: {fileID: 6703844820478198895}
+      objectReference: {fileID: 4636399703202130992}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Target
+      value: 
+      objectReference: {fileID: 4636399703202130992}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Target
+      value: 
+      objectReference: {fileID: 4636399703202130992}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
@@ -12052,48 +12068,92 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: PlayFeedbacks
-      objectReference: {fileID: 0}
-    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
-      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
-      value: Launch
-      objectReference: {fileID: 0}
-    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
-      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
       value: OnDeath
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: PlayFeedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_MethodName
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_MethodName
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+      value: BML.Scripts.EnemySpawnable, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
-      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      value: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
-      value: BML.Scripts.EnemySpawnable, BML.Scripts
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgument
       value: 
-      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+      objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgument
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.GameObject, UnityEngine
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 704199864178533153, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: graphMask.value

--- a/Assets/Entities/Enemy/BombEnemy/BombEnemy.prefab
+++ b/Assets/Entities/Enemy/BombEnemy/BombEnemy.prefab
@@ -13268,7 +13268,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
@@ -13276,12 +13276,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
-      value: 1
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Mode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Mode
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 1908075267925493770}
+      objectReference: {fileID: 1870709328736205188}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
@@ -13289,7 +13297,15 @@ PrefabInstance:
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Target
       value: 
-      objectReference: {fileID: 1870709328736205188}
+      objectReference: {fileID: 1908075267925493770}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Target
+      value: 
+      objectReference: {fileID: 1908075267925493770}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Target
+      value: 
+      objectReference: {fileID: 1908075267925493770}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
@@ -13303,8 +13319,16 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: Launch
+      value: OnDeath
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
@@ -13312,11 +13336,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
-      value: OnDeath
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_MethodName
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_MethodName
+      value: Launch
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      value: BML.Scripts.EnemySpawnable, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
@@ -13324,15 +13356,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
-      value: BML.Scripts.EnemySpawnable, BML.Scripts
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgument
+      value: 
       objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.GameObject, UnityEngine
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -13340,7 +13392,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 2157732797319386836, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Entities/Enemy/SlimeEnemy/SlimeEnemy.prefab
+++ b/Assets/Entities/Enemy/SlimeEnemy/SlimeEnemy.prefab
@@ -6352,13 +6352,21 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 3821147435045339496}
+      objectReference: {fileID: 5617157844206123741}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
-      objectReference: {fileID: 5617157844206123741}
+      objectReference: {fileID: 3821147435045339496}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Target
+      value: 
+      objectReference: {fileID: 3821147435045339496}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
@@ -6368,20 +6376,32 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
-      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: PlayFeedbacks
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_CallState
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
-      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
       value: OnDeath
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: PlayFeedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: PlayFeedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+      value: BML.Scripts.EnemySpawnable, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
-      value: BML.Scripts.EnemySpawnable, BML.Scripts
+      value: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
+      value: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -6389,6 +6409,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 2157732797319386836, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}

--- a/Assets/Entities/Enemy/SlimeEnemy/SlimeEnemy_Small.prefab
+++ b/Assets/Entities/Enemy/SlimeEnemy/SlimeEnemy_Small.prefab
@@ -89,14 +89,30 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.size
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Mode
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Target
+      value: 
+      objectReference: {fileID: 5855007100718197981}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Target
+      value: 
+      objectReference: {fileID: 555452909022470292}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Target
       value: 
       objectReference: {fileID: 555452909022470292}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
@@ -104,19 +120,59 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: PlayFeedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_MethodName
       value: Launch
       objectReference: {fileID: 0}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
+      value: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_TargetAssemblyTypeName
       value: BML.Scripts.RigidBodyLauncher, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgument
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgument
+      value: 
       objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
     - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808216174104718560, guid: 40715c857926914489d8ac34029b4c92, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.GameObject, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 3821147435045339496, guid: 40715c857926914489d8ac34029b4c92, type: 3}

--- a/Assets/Entities/Enemy/SnakeEnemy/SnakeEnemy.prefab
+++ b/Assets/Entities/Enemy/SnakeEnemy/SnakeEnemy.prefab
@@ -10457,7 +10457,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
@@ -10465,12 +10465,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
-      value: 1
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Mode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Mode
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 6062676856020985799}
+      objectReference: {fileID: 7489235882652537123}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
@@ -10478,7 +10486,15 @@ PrefabInstance:
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Target
       value: 
-      objectReference: {fileID: 7489235882652537123}
+      objectReference: {fileID: 6062676856020985799}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Target
+      value: 
+      objectReference: {fileID: 6062676856020985799}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Target
+      value: 
+      objectReference: {fileID: 6062676856020985799}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
@@ -10492,8 +10508,16 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: Launch
+      value: OnDeath
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
@@ -10501,11 +10525,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
-      value: OnDeath
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_MethodName
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_MethodName
+      value: Launch
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      value: BML.Scripts.EnemySpawnable, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
@@ -10513,15 +10545,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
-      value: BML.Scripts.EnemySpawnable, BML.Scripts
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgument
+      value: 
       objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.GameObject, UnityEngine
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -10529,7 +10581,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 2157732797319386836, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Entities/Enemy/ZombieEnemy/ZombieEnemy.prefab
+++ b/Assets/Entities/Enemy/ZombieEnemy/ZombieEnemy.prefab
@@ -17391,7 +17391,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Mode
@@ -17399,12 +17399,20 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Mode
-      value: 1
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Mode
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Mode
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 1908075267925493770}
+      objectReference: {fileID: 1870709328736205188}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
@@ -17412,7 +17420,15 @@ PrefabInstance:
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Target
       value: 
-      objectReference: {fileID: 1870709328736205188}
+      objectReference: {fileID: 1908075267925493770}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Target
+      value: 
+      objectReference: {fileID: 1908075267925493770}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Target
+      value: 
+      objectReference: {fileID: 1908075267925493770}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
@@ -17426,8 +17442,16 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: Launch
+      value: OnDeath
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
@@ -17435,11 +17459,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_MethodName
-      value: OnDeath
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_MethodName
+      value: Launch
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_MethodName
+      value: Launch
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      value: BML.Scripts.EnemySpawnable, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_TargetAssemblyTypeName
@@ -17447,15 +17479,35 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_TargetAssemblyTypeName
-      value: BML.Scripts.EnemySpawnable, BML.Scripts
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_TargetAssemblyTypeName
+      value: BML.Scripts.RigidBodyLauncher, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgument
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgument
+      value: 
+      objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgument
+      value: 
       objectReference: {fileID: 2593184574423224280, guid: 031888ecd2537c742b2ebfda7fc8fa7d, type: 3}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.GameObject, UnityEngine
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[2].m_Arguments.m_ObjectArgumentAssemblyTypeName
@@ -17463,7 +17515,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[3].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[4].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 664713299843294227, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
+      propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[5].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.GameObject, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 2157732797319386836, guid: 5e5e72975584f5049bc0e445a185fa69, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Entities/EnemySpawner/EnemySpawnManager.prefab
+++ b/Assets/Entities/EnemySpawner/EnemySpawnManager.prefab
@@ -202,7 +202,8 @@ MonoBehaviour:
         PlaybackTime: {x: 0, y: 0}
         MmSoundManagerTrack: 0
         ID: 0
-        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c, type: 2}
+        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c,
+          type: 2}
         RecycleAudioSource: {fileID: 0}
         Loop: 0
         Persistent: 0
@@ -257,7 +258,8 @@ MonoBehaviour:
         MinDistance: 1
         MaxDistance: 500
     00000001:
-      type: {class: MMF_CinemachineImpulse, ns: MoreMountains.FeedbacksForThirdParty, asm: MoreMountains.Feedbacks.Cinemachine}
+      type: {class: MMF_CinemachineImpulse, ns: MoreMountains.FeedbacksForThirdParty,
+        asm: MoreMountains.Feedbacks.Cinemachine}
       data:
         Active: 1
         UniqueID: 794151459
@@ -326,7 +328,8 @@ MonoBehaviour:
         DebugActive: 0
         m_ImpulseDefinition:
           m_ImpulseChannel: 1
-          m_RawSignal: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+          m_RawSignal: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4,
+            type: 2}
           m_AmplitudeGain: 2.5
           m_FrequencyGain: 0.25
           m_RepeatMode: 0
@@ -463,7 +466,8 @@ MonoBehaviour:
         PlayEvents:
           m_PersistentCalls:
             m_Calls:
-            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74, type: 2}
+            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74,
+                type: 2}
               m_TargetAssemblyTypeName: BML.ScriptableObjectCore.Scripts.Events.DynamicGameEvent,
                 ScriptableObjectSystem
               m_MethodName: Raise
@@ -687,7 +691,8 @@ MonoBehaviour:
         PlaybackTime: {x: 0, y: 0}
         MmSoundManagerTrack: 0
         ID: 0
-        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c, type: 2}
+        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c,
+          type: 2}
         RecycleAudioSource: {fileID: 0}
         Loop: 0
         Persistent: 0
@@ -742,7 +747,8 @@ MonoBehaviour:
         MinDistance: 1
         MaxDistance: 500
     00000001:
-      type: {class: MMF_CinemachineImpulse, ns: MoreMountains.FeedbacksForThirdParty, asm: MoreMountains.Feedbacks.Cinemachine}
+      type: {class: MMF_CinemachineImpulse, ns: MoreMountains.FeedbacksForThirdParty,
+        asm: MoreMountains.Feedbacks.Cinemachine}
       data:
         Active: 1
         UniqueID: 1332312607
@@ -811,7 +817,8 @@ MonoBehaviour:
         DebugActive: 0
         m_ImpulseDefinition:
           m_ImpulseChannel: 1
-          m_RawSignal: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+          m_RawSignal: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4,
+            type: 2}
           m_AmplitudeGain: 2.5
           m_FrequencyGain: 0.25
           m_RepeatMode: 0
@@ -948,7 +955,8 @@ MonoBehaviour:
         PlayEvents:
           m_PersistentCalls:
             m_Calls:
-            - m_Target: {fileID: 11400000, guid: 202338784c98ffc45af987272ea6fc5b, type: 2}
+            - m_Target: {fileID: 11400000, guid: 202338784c98ffc45af987272ea6fc5b,
+                type: 2}
               m_TargetAssemblyTypeName: BML.ScriptableObjectCore.Scripts.Events.GameEvent,
                 ScriptableObjectSystem
               m_MethodName: Raise
@@ -961,7 +969,8 @@ MonoBehaviour:
                 m_StringArgument: 
                 m_BoolArgument: 0
               m_CallState: 2
-            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74, type: 2}
+            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74,
+                type: 2}
               m_TargetAssemblyTypeName: BML.ScriptableObjectCore.Scripts.Events.DynamicGameEvent,
                 ScriptableObjectSystem
               m_MethodName: Raise
@@ -1185,7 +1194,8 @@ MonoBehaviour:
         PlaybackTime: {x: 0, y: 0}
         MmSoundManagerTrack: 0
         ID: 0
-        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c, type: 2}
+        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c,
+          type: 2}
         RecycleAudioSource: {fileID: 0}
         Loop: 0
         Persistent: 0
@@ -1240,7 +1250,8 @@ MonoBehaviour:
         MinDistance: 1
         MaxDistance: 500
     00000001:
-      type: {class: MMF_CinemachineImpulse, ns: MoreMountains.FeedbacksForThirdParty, asm: MoreMountains.Feedbacks.Cinemachine}
+      type: {class: MMF_CinemachineImpulse, ns: MoreMountains.FeedbacksForThirdParty,
+        asm: MoreMountains.Feedbacks.Cinemachine}
       data:
         Active: 1
         UniqueID: 1332312607
@@ -1309,7 +1320,8 @@ MonoBehaviour:
         DebugActive: 0
         m_ImpulseDefinition:
           m_ImpulseChannel: 1
-          m_RawSignal: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4, type: 2}
+          m_RawSignal: {fileID: 11400000, guid: 69ce8388f6785dd4c8c39915efece2f4,
+            type: 2}
           m_AmplitudeGain: 2.5
           m_FrequencyGain: 0.25
           m_RepeatMode: 0
@@ -1446,7 +1458,8 @@ MonoBehaviour:
         PlayEvents:
           m_PersistentCalls:
             m_Calls:
-            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74, type: 2}
+            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74,
+                type: 2}
               m_TargetAssemblyTypeName: BML.ScriptableObjectCore.Scripts.Events.DynamicGameEvent,
                 ScriptableObjectSystem
               m_MethodName: Raise
@@ -1703,7 +1716,8 @@ MonoBehaviour:
         PlaybackTime: {x: 0, y: 0}
         MmSoundManagerTrack: 0
         ID: 0
-        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c, type: 2}
+        AudioGroup: {fileID: 8502747269616987881, guid: b88f15b5f1de54e4e8cb1b4899763f5c,
+          type: 2}
         RecycleAudioSource: {fileID: 0}
         Loop: 0
         Persistent: 0
@@ -1828,7 +1842,8 @@ MonoBehaviour:
         PlayEvents:
           m_PersistentCalls:
             m_Calls:
-            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74, type: 2}
+            - m_Target: {fileID: 11400000, guid: 171ca609259d198498140da98e0d8b74,
+                type: 2}
               m_TargetAssemblyTypeName: BML.ScriptableObjectCore.Scripts.Events.DynamicGameEvent,
                 ScriptableObjectSystem
               m_MethodName: Raise
@@ -1901,17 +1916,17 @@ MonoBehaviour:
   IsDespawningPaused: 0
   _caveGenerator: {fileID: 0}
   _enemyContainer: {fileID: 0}
-  _terrainLayerMask:
-    serializedVersion: 2
-    m_Bits: 8200
-  _maxRaycastLength: 10
   _despawnNodeDistance: 4
   _isSpawningPaused: {fileID: 11400000, guid: b4e7a4ec09d24a747b1a8f247eee964d, type: 2}
   _currentEnemyCount: {fileID: 11400000, guid: 6fdcc6ab717b88f4fa6f8ecf81b9db82, type: 2}
-  _hasPlayerExitedStartRoom: {fileID: 11400000, guid: 7e64dee33977c4244bc70a927d83e4f2, type: 2}
+  _hasPlayerExitedStartRoom: {fileID: 11400000, guid: 7e64dee33977c4244bc70a927d83e4f2,
+    type: 2}
   _onEnemyKilled: {fileID: 11400000, guid: 27655ba7f3ad5234e9ec5c21a9e2abd5, type: 2}
-  _onAfterGenerateLevelObjects: {fileID: 11400000, guid: 6b14c457b3e8a0446918006e4929ed06, type: 2}
-  _enemySpawnerParams: {fileID: 11400000, guid: 610add04d36c99744b8634adbf223abc, type: 2}
+  _onAfterGenerateLevelObjects: {fileID: 11400000, guid: 6b14c457b3e8a0446918006e4929ed06,
+    type: 2}
+  _enemySpawnerParams: {fileID: 11400000, guid: 610add04d36c99744b8634adbf223abc,
+    type: 2}
+  _immediateSpawnDelay: 0.5
   _minMaxSpawnPlayerDistance: {x: 1, y: 2}
   _weightSpawningInUnexplored: 0.5
   _weightSpawningTowardsObjective: 0.6
@@ -1941,13 +1956,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 857976c1b4d74a6790dda9e9f2dbebb0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _playerTransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122, type: 2}
-  _playerHealthSceneReference: {fileID: 11400000, guid: fb7b2e3ba8a4e724aa1716fcc22f0007, type: 2}
+  _playerTransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122,
+    type: 2}
+  _playerHealthSceneReference: {fileID: 11400000, guid: fb7b2e3ba8a4e724aa1716fcc22f0007,
+    type: 2}
   _enemySpawnManager: {fileID: 9182727736491517644}
   _intensityScore:
     ReferenceTypeSelector: 1
     ConstantValue: 0
-    ReferenceValue_FloatVariable: {fileID: 11400000, guid: b9ffab9e48115f84e9ac88db538de371, type: 2}
+    ReferenceValue_FloatVariable: {fileID: 11400000, guid: b9ffab9e48115f84e9ac88db538de371,
+      type: 2}
     ReferenceValue_IntVariable: {fileID: 0}
     ReferenceValue_EvaluateCurveVariable: {fileID: 0}
   _intensityScoreUpdatePeriod: 1
@@ -1969,7 +1987,8 @@ MonoBehaviour:
   _despawnIdleEnemies: 1
   _despawnIdleEnemyDistance: 1
   _isSpawningPaused: {fileID: 11400000, guid: b4e7a4ec09d24a747b1a8f247eee964d, type: 2}
-  _hasPlayerExitedStartRoom: {fileID: 11400000, guid: 7e64dee33977c4244bc70a927d83e4f2, type: 2}
+  _hasPlayerExitedStartRoom: {fileID: 11400000, guid: 7e64dee33977c4244bc70a927d83e4f2,
+    type: 2}
   _enableLogs: 0
 --- !u!114 &4668978062262992813
 MonoBehaviour:
@@ -1984,8 +2003,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _enemySpawnManager: {fileID: 9182727736491517644}
-  _currentPercentToMaxSpawn: {fileID: 11400000, guid: 88289707eab0e224fa8a2607ca189c06, type: 2}
-  _playerTransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122, type: 2}
+  _intensityScore: {fileID: 11400000, guid: b9ffab9e48115f84e9ac88db538de371, type: 2}
+  _currentPercentToMaxSpawn: {fileID: 11400000, guid: 88289707eab0e224fa8a2607ca189c06,
+    type: 2}
+  _playerTransformSceneReference: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122,
+    type: 2}
 --- !u!114 &1471086886
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1999,8 +2021,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _wormSpawnTimer: {fileID: 11400000, guid: 6ce90ebfc6beece4cb0d32bfa065bc41, type: 2}
-  _playerHasExitedStartRoom: {fileID: 11400000, guid: 7e64dee33977c4244bc70a927d83e4f2, type: 2}
-  _wormMaxStrengthTimer: {fileID: 11400000, guid: 1426a9071e46b2047baec5cf66031a71, type: 2}
+  _playerHasExitedStartRoom: {fileID: 11400000, guid: 7e64dee33977c4244bc70a927d83e4f2,
+    type: 2}
+  _wormMaxStrengthTimer: {fileID: 11400000, guid: 1426a9071e46b2047baec5cf66031a71,
+    type: 2}
   _spawnRadius: 50
   _speedCurve:
     serializedVersion: 2
@@ -2061,6 +2085,7 @@ MonoBehaviour:
     TimeOffsetFromSpawn: 60
     Feedback: {fileID: 6676880402962278586}
   _wormActivatedFeedback: {fileID: 6929418385190707709}
-  _wormPrefab: {fileID: 8742083633597919030, guid: 0f648f933ac990044b4aedcd81f1ff54, type: 3}
+  _wormPrefab: {fileID: 8742083633597919030, guid: 0f648f933ac990044b4aedcd81f1ff54,
+    type: 3}
   _playerRef: {fileID: 11400000, guid: 0a3164266f381ad4ca02410613c2a122, type: 2}
   _enableDebug: 0

--- a/Assets/Entities/EnemySpawner/Levels/EnemySpawnParams_Level0.asset
+++ b/Assets/Entities/EnemySpawner/Levels/EnemySpawnParams_Level0.asset
@@ -14,76 +14,60 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SpawnDelay: 5
   SpawnCap: 6
+  MaxIntensity: 5
+  MinIntesity: 1
   SpawnAtTags:
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 3507841168381770313, guid: d315f707aa867be468a329805e25ff00, type: 3}
     Cost: 5
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.1
     RequireStableSurface: 0
     InstanceAsPrefab: 0
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
-    NormalizedSpawnWeight: 0.34710744
+    NormalizedSpawnWeight: 0.328125
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 1677924739546840732, guid: eec6ca1e334e7e145ac42771c90e8179, type: 3}
     Cost: 20
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.1
     RequireStableSurface: 0
     InstanceAsPrefab: 0
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
-    NormalizedSpawnWeight: 0.08677686
+    NormalizedSpawnWeight: 0.08203125
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 2994263931833974615, guid: ce73dde8373653a4bbfcdc9852a04b32, type: 3}
     Cost: 10
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.1
     RequireStableSurface: 0
     InstanceAsPrefab: 1
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
-    NormalizedSpawnWeight: 0.17355372
+    NormalizedSpawnWeight: 0.1640625
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 5467598045441333570, guid: 3db68b5c3ac9af2448a5549635ad3114, type: 3}
     Cost: 12
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.1
     RequireStableSurface: 0
     InstanceAsPrefab: 1
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
-    NormalizedSpawnWeight: 0.1446281
+    NormalizedSpawnWeight: 0.13671875
   - Tag: Spawn_Enemy_Bat
     Prefab: {fileID: 1289867755587324221, guid: 64d12ac9516ff134dadbb34c91ac7de8, type: 3}
     Cost: 7
-    RaycastDirection: {x: 0, y: 1, z: 0}
-    RaycastOffset: 5
     SpawnPosOffset: 1.2
     SpawnRadiusOffset: 0.5
     RequireStableSurface: 1
     InstanceAsPrefab: 1
     OccupySpawnPoint: 1
-    SpawnInPlayerVistedRooms: 0
-    NormalizedSpawnWeight: 0.24793388
+    NormalizedSpawnWeight: 0.234375
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 2994263931833974615, guid: eec51464d5a50e444afccb958699bea6, type: 3}
     Cost: 30
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.5
     RequireStableSurface: 0
     InstanceAsPrefab: 0
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
-    NormalizedSpawnWeight: 0
+    NormalizedSpawnWeight: 0.0546875

--- a/Assets/Entities/EnemySpawner/Levels/EnemySpawnParams_Level1.asset
+++ b/Assets/Entities/EnemySpawner/Levels/EnemySpawnParams_Level1.asset
@@ -14,76 +14,60 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   SpawnDelay: 1.5
   SpawnCap: 10
+  MaxIntensity: 5
+  MinIntesity: 1
   SpawnAtTags:
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 1677924739546840732, guid: eec6ca1e334e7e145ac42771c90e8179, type: 3}
     Cost: 14
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.1
     RequireStableSurface: 0
     InstanceAsPrefab: 0
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
     NormalizedSpawnWeight: 0.089552246
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 3736061381085002444, guid: bc14983e8efe0f3408c0fb14dbe6a222, type: 3}
     Cost: 6
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.1
     RequireStableSurface: 0
     InstanceAsPrefab: 1
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
     NormalizedSpawnWeight: 0.20895523
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 7924871544518895807, guid: 436a8dccaea4fc44fb1dbd1410826268, type: 3}
     Cost: 6
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.1
     RequireStableSurface: 0
     InstanceAsPrefab: 1
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
     NormalizedSpawnWeight: 0.20895523
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 6617389194688458723, guid: ed0747bed2e687b42bd6e1c4a056dd36, type: 3}
     Cost: 4
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.5
     RequireStableSurface: 0
     InstanceAsPrefab: 0
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
     NormalizedSpawnWeight: 0.31343284
   - Tag: Spawn_Enemy_Bat
     Prefab: {fileID: 9217897901852441904, guid: 070c604411d01f04092cad9a204fd5df, type: 3}
     Cost: 7
-    RaycastDirection: {x: 0, y: 1, z: 0}
-    RaycastOffset: 5
     SpawnPosOffset: 1.2
     SpawnRadiusOffset: 0.5
     RequireStableSurface: 1
     InstanceAsPrefab: 1
     OccupySpawnPoint: 1
-    SpawnInPlayerVistedRooms: 0
     NormalizedSpawnWeight: 0.17910449
   - Tag: Spawn_Enemy_Zombie
     Prefab: {fileID: 2994263931833974615, guid: eec51464d5a50e444afccb958699bea6, type: 3}
     Cost: 15
-    RaycastDirection: {x: 0, y: -1, z: 0}
-    RaycastOffset: 0
     SpawnPosOffset: 0
     SpawnRadiusOffset: 0.5
     RequireStableSurface: 0
     InstanceAsPrefab: 0
     OccupySpawnPoint: 0
-    SpawnInPlayerVistedRooms: 1
     NormalizedSpawnWeight: 0

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeConnectionData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeConnectionData.cs
@@ -37,7 +37,6 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             => Mathf.RoundToInt((Source.PlayerDistanceDelta + Target.PlayerDistanceDelta) / 2f);
         [ShowInInspector] public float DirectPlayerDistance
             => Mathf.Min(Source.DirectPlayerDistance, Target.DirectPlayerDistance);
-        
         [ShowInInspector] 
         public bool PlayerVisited
         {
@@ -45,8 +44,9 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             set
             {
                 if (!playerVisited && value)
+                {
                     OnPlayerVisited();
-                
+                }
                 playerVisited = value;
             }
         }

--- a/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeData.cs
+++ b/Assets/Scripts/CaveV2/CaveGraph/NodeData/CaveNodeData.cs
@@ -24,7 +24,6 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
         [ShowInInspector] public int PlayerDistance { get; set; }
         [ShowInInspector] public int PlayerDistanceDelta { get; set; }
         [ShowInInspector] public float DirectPlayerDistance { get; set; }
-        
         [ShowInInspector]
         public bool PlayerVisited
         {
@@ -32,8 +31,9 @@ namespace BML.Scripts.CaveV2.CaveGraph.NodeData
             set
             {
                 if (!playerVisited && value)
+                {
                     OnPlayerVisited();
-                
+                }
                 playerVisited = value;
             }
         }

--- a/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
@@ -262,7 +262,9 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         private void OnPlayerVisited(object o, EventArgs e)
         {
             if (_disableIfPlayerVisited)
+            {
                 SpawnChance = 0f;
+            }
         }
 
         private void DrawDebugMesh(Vector3 position)

--- a/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
@@ -23,8 +23,47 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         }
         
         #region Inspector
+        
+        [ShowInInspector, ReadOnly, InfoBox("This spawn point will not be found if it's untagged!", InfoMessageType.Error, "@_isUntagged"), PropertyOrder(-1)] 
+        private string _tag => this.tag;
+        private bool _isUntagged => _tag == null || _tag == "Untagged";
 
-        [ShowInInspector, ReadOnly]
+        [TitleGroup("Projection behavior")]
+        [SerializeField, HideLabel] private SpawnPointProjectionBehavior _projectionBehavior;
+        [SerializeField] private LayerMask _projectionLayerMask;
+        [SerializeField, ShowIf("@this._projectionBehavior == SpawnPointProjectionBehavior.Vector || this._projectionBehavior == SpawnPointProjectionBehavior.Randomize")] 
+        private Vector3 _projectionVector = Vector3.down;
+        [SerializeField, ShowIf("@this._projectionBehavior == SpawnPointProjectionBehavior.Randomize")] 
+        private Vector2 _projectionDirectionRandomnessRangeDegrees = new Vector2(30, 15);
+        [SerializeField] private float _projectionDistance = 45f;
+
+        [SerializeField] private bool _doInheritParentRotation = true;
+        [SerializeField] private bool _rotateTowardsSurfaceNormal = true;
+        [SerializeField] private Vector3 _rotationEulerOffset = Vector3.zero;
+        
+        [SerializeField, ReadOnly] private Vector3? _projectedPosition = null; 
+        [SerializeField, ReadOnly] private Quaternion? _projectedRotation = null; 
+        
+        [TitleGroup("Spawn behavior")]
+        [SerializeField] [Range(0f, 1f)] private float _startingSpawnChance = 1f;
+        [SerializeField] private bool _disableIfPlayerVisited = false;
+        [SerializeField, Tooltip("If the last enemy to occupy this spawn point was despawned, this will ensure they get respawned immediately when the spawn point is active again.")] 
+        private bool _persistSpawns = false;
+        [ShowInInspector, ReadOnly] private bool _previousSpawnWasDespawned = false;
+        [SerializeField, Tooltip("Guarantees this spawn point will be populated as soon as it becomes active.")] 
+        private bool _guaranteeSpawnIfInRange = false;
+        [SerializeField, Tooltip("Prevents more than one enemy from spawning here at a time. No other enemy can spawn until the occupier either dies or despawns.")] 
+        private bool _limitToOneSpawnAtATime = false;
+        [SerializeField, Tooltip("Limit the number of enemies this spawner can produce for it's lifetime.")] 
+        private int _spawnLimit = -1;
+        [ShowInInspector, ReadOnly] private int _spawnCount = 0;
+        [SerializeField, Tooltip("If enabled, the above 'spawn limit' will only be applied to spawns from 'guarantee spawn if in range'; after the limit is reached guaranteed spawns will cease, but the spawn point will still be available for the EnemySpawnManager to repopulate through it's normal spawning routine.")] 
+        private bool _applySpawnLimitOnlyToGuaranteedSpawns = false;
+        [SerializeField, Tooltip("Ignore the EnemySpawnManager's global concurrent spawn limit.")] public bool IgnoreGlobalSpawnCap = false;
+
+        [FoldoutGroup("Debug"), SerializeField] private bool _showDebugPrefab;
+        [FoldoutGroup("Debug"), SerializeField] private GameObject _debugPrefab;
+        [FoldoutGroup("Debug"), ShowInInspector, ReadOnly] private ICaveNodeData parentNode;
         public ICaveNodeData ParentNode
         {
             get => parentNode;
@@ -36,56 +75,20 @@ namespace BML.Scripts.CaveV2.SpawnObjects
                 _projectedRotation = null;
             }
         }
-
-        [SerializeField] private SpawnPointProjectionBehavior _projectionBehavior;
-        [SerializeField] private LayerMask _projectionLayerMask;
-        [SerializeField, ShowIf("@this._projectionBehavior == SpawnPointProjectionBehavior.Vector || this._projectionBehavior == SpawnPointProjectionBehavior.Randomize")] 
-        private Vector3 _projectionVector = Vector3.down;
-        [SerializeField, ShowIf("@this._projectionBehavior == SpawnPointProjectionBehavior.Randomize")] 
-        private Vector2 _projectionDirectionRandomnessRangeDegrees = new Vector2(30, 15);
-        [SerializeField] private float _projectionDistance = 45f;
-
-        [SerializeField] private bool _doInheritParentRotation = true;
-        [SerializeField] private bool _rotateTowardsSurfaceNormal = true;
-        [SerializeField] private Vector3 _rotationEulerOffset = Vector3.zero;
-        [SerializeField, ReadOnly] private Vector3? _projectedPosition = null; 
-        [SerializeField, ReadOnly] private Quaternion? _projectedRotation = null; 
         
-        [SerializeField] [Range(0f, 1f)] private float _startingSpawnChance = 1f;
-        [SerializeField] private bool _disableIfPlayerVisited;
-
-        [SerializeField] private bool _persistSpawns = false;
-        [ShowInInspector, ReadOnly] private bool _previousSpawnWasDespawned = false;
-        [SerializeField] private bool _guaranteeSpawnIfInRange = false;
-        [SerializeField] private bool _limitToOneSpawnAtATime = false;
-        [SerializeField] private int _spawnLimit = -1;
-        [SerializeField] private bool _applySpawnLimitOnlyToGuaranteedSpawns = false;
-        [ShowInInspector, ReadOnly] private int _spawnCount = 0;
-        [SerializeField] public bool IgnoreGlobalSpawnCap = false;
-        
-        [ShowInInspector, ReadOnly] public bool Occupied;
-
-        [ShowInInspector, ReadOnly]
+        [FoldoutGroup("Current state"), ShowInInspector, ReadOnly] public bool Occupied;
+        [FoldoutGroup("Current state"), ShowInInspector, ReadOnly]
         public float SpawnChance
         {
             get => _spawnChance * (!_applySpawnLimitOnlyToGuaranteedSpawns && _spawnLimit > -1 && _spawnCount >= _spawnLimit ? 0 : 1);
             set => _spawnChance = value;
         }
-
         private float _spawnChance = 1f;
-        [ShowInInspector, ReadOnly] public bool SpawnImmediate => ((_guaranteeSpawnIfInRange && (_spawnLimit <= -1 || _spawnLimit > _spawnCount)) 
+        
+        [FoldoutGroup("Current state"), ShowInInspector, ReadOnly] public bool SpawnImmediate => ((_guaranteeSpawnIfInRange && (_spawnLimit <= -1 || _spawnLimit > _spawnCount)) 
                                                                    || (_persistSpawns && _previousSpawnWasDespawned));
-        [ShowInInspector, ReadOnly] public float EnemySpawnWeight { get; set; } = 1f;
-        
-        [SerializeField] private bool _showDebugPrefab;
-        [SerializeField] private GameObject _debugPrefab;
+        [FoldoutGroup("Current state"), ShowInInspector, ReadOnly] public float EnemySpawnWeight { get; set; } = 1f;
 
-        private ICaveNodeData parentNode;
-
-        // TODO fetch current object tag and display it. Show a warning/error if object is NOT tagged.
-        [ShowInInspector, ReadOnly, InfoBox("", InfoMessageType.Error, "@this.tag")] 
-        private string _tag => this.tag;
-        
         #endregion
 
         #region Unity lifecycle
@@ -165,8 +168,8 @@ namespace BML.Scripts.CaveV2.SpawnObjects
             // TODO calculate base on object parameters
         }
 
-        [Button]
-        private void Test()
+        [TitleGroup("Projection behavior"), Button]
+        private void TestProjection()
         {
             Project();
         }

--- a/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
@@ -42,8 +42,8 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         [SerializeField] private bool _rotateTowardsSurfaceNormal = true;
         [SerializeField] private Vector3 _rotationEulerOffset = Vector3.zero;
         
-        [SerializeField, ReadOnly] private Vector3? _projectedPosition = null; 
-        [SerializeField, ReadOnly] private Quaternion? _projectedRotation = null; 
+        [ShowInInspector, ReadOnly] private Vector3? _projectedPosition = null; 
+        [ShowInInspector, ReadOnly] private Quaternion? _projectedRotation = null; 
         
         [TitleGroup("Spawn behavior")]
         [SerializeField] [Range(0f, 1f)] private float _startingSpawnChance = 1f;
@@ -134,6 +134,7 @@ namespace BML.Scripts.CaveV2.SpawnObjects
                     Gizmos.DrawRay(position, this.transform.TransformDirection(_projectionVector));
                 }
                 
+                // Project();
                 Project();
                 if (_projectedPosition != null && _projectedPosition != position)
                 {

--- a/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
@@ -8,6 +8,7 @@ using Sirenix.OdinInspector;
 using Sirenix.Utilities;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Serialization;
 using Random = UnityEngine.Random;
 
 namespace BML.Scripts.CaveV2.SpawnObjects
@@ -56,10 +57,15 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         private bool _limitToOneSpawnAtATime = false;
         [SerializeField, Tooltip("Limit the number of enemies this spawner can produce for it's lifetime.")] 
         private int _spawnLimit = -1;
+        [ShowInInspector, ReadOnly] public bool ReachedSpawnLimit => (_spawnLimit > -1 && _spawnCount >= _spawnLimit);
         [ShowInInspector, ReadOnly] private int _spawnCount = 0;
         [SerializeField, Tooltip("If enabled, the above 'spawn limit' will only be applied to spawns from 'guarantee spawn if in range'; after the limit is reached guaranteed spawns will cease, but the spawn point will still be available for the EnemySpawnManager to repopulate through it's normal spawning routine.")] 
         private bool _applySpawnLimitOnlyToGuaranteedSpawns = false;
-        [SerializeField, Tooltip("Ignore the EnemySpawnManager's global concurrent spawn limit.")] public bool IgnoreGlobalSpawnCap = false;
+        [FormerlySerializedAs("IgnoreGlobalSpawnCap")] [SerializeField, Tooltip("Ignore the EnemySpawnManager's global concurrent spawn limit.")] 
+        private bool _ignoreGlobalSpawnCap = false;
+        [ShowInInspector, ReadOnly] public bool IgnoreGlobalSpawnCap => _ignoreGlobalSpawnCap && (!OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns || (_guaranteeSpawnIfInRange && (_spawnLimit <= -1 || _spawnLimit >= _spawnCount))); 
+        [SerializeField] 
+        public bool OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns = true; 
 
         [FoldoutGroup("Debug"), SerializeField] private bool _showDebugPrefab;
         [FoldoutGroup("Debug"), SerializeField] private GameObject _debugPrefab;

--- a/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
@@ -59,6 +59,7 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         [SerializeField] private bool _guaranteeSpawnIfInRange = false;
         [SerializeField] private bool _limitToOneSpawnAtATime = false;
         [SerializeField] private int _spawnLimit = -1;
+        [SerializeField] private bool _applySpawnLimitOnlyToGuaranteedSpawns = false;
         [ShowInInspector, ReadOnly] private int _spawnCount = 0;
         [SerializeField] public bool IgnoreGlobalSpawnCap = false;
         
@@ -67,12 +68,13 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         [ShowInInspector, ReadOnly]
         public float SpawnChance
         {
-            get => _spawnChance * (_spawnLimit > -1 && _spawnCount >= _spawnLimit ? 0 : 1);
+            get => _spawnChance * (!_applySpawnLimitOnlyToGuaranteedSpawns && _spawnLimit > -1 && _spawnCount >= _spawnLimit ? 0 : 1);
             set => _spawnChance = value;
         }
 
         private float _spawnChance = 1f;
-        [ShowInInspector, ReadOnly] public bool SpawnImmediate => (_guaranteeSpawnIfInRange || (_persistSpawns && _previousSpawnWasDespawned));
+        [ShowInInspector, ReadOnly] public bool SpawnImmediate => ((_guaranteeSpawnIfInRange && (_spawnLimit <= -1 || _spawnLimit > _spawnCount)) 
+                                                                   || (_persistSpawns && _previousSpawnWasDespawned));
         [ShowInInspector, ReadOnly] public float EnemySpawnWeight { get; set; } = 1f;
         
         [SerializeField] private bool _showDebugPrefab;

--- a/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
+++ b/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
@@ -368,6 +368,7 @@ namespace BML.Scripts
             List<SpawnPoint> potentialSpawnPointsForTag = _activeSpawnPointsByTag[randomEnemyParams.Tag]
                 .Where(spawnPoint => spawnPoint.EnemySpawnWeight != 0 && !spawnPoint.Occupied
                     && (!reachedGlobalSpawnCap || spawnPoint.IgnoreGlobalSpawnCap)
+                    && !spawnPoint.SpawnImmediate
                 ).ToList();
             
             // If no spawn points in range for this tag, return
@@ -393,6 +394,7 @@ namespace BML.Scripts
             SpawnPoint randomSpawnPoint = RandomUtils.RandomWithWeights(spawnPointWeights);
 
             // Calculate random spawn position offset
+            // TODO refactor to fixed offset?
             var randomOffset = Random.insideUnitCircle;
             var spawnPosition = randomSpawnPoint.transform.position +
                              new Vector3(randomOffset.x, 0f, randomOffset.y) * randomEnemyParams.SpawnRadiusOffset;
@@ -436,6 +438,7 @@ namespace BML.Scripts
                 {
                     var enemyParamsForTag =
                         _enemySpawnerParams.SpawnAtTags.FirstOrDefault(enemySpawnerParams => enemySpawnerParams.Tag == kv.Key);
+                    // TODO because there are currently many types of enemies all being spawned with the same tag, this will always spawn the small slime (first enemy in list) even though it could be many others.
                     if (enemyParamsForTag == null)
                     {
                         continue;

--- a/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
+++ b/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
@@ -367,8 +367,7 @@ namespace BML.Scripts
             List<SpawnPoint> potentialSpawnPointsForTag = _activeSpawnPointsByTag[randomEnemyParams.Tag]
                 .Where(spawnPoint => spawnPoint.EnemySpawnWeight != 0 && !spawnPoint.Occupied
                     && (!reachedGlobalSpawnCap || spawnPoint.IgnoreGlobalSpawnCap)
-                    && (randomEnemyParams.SpawnInPlayerVistedRooms || !spawnPoint.ParentNode.PlayerVisited)) // TODO what actually uses SpawnInPlayerVisitedRooms?
-                .ToList();
+                ).ToList();
             
             // If no spawn points in range for this tag, return
             if (potentialSpawnPointsForTag.Count == 0)

--- a/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
+++ b/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
@@ -445,35 +445,35 @@ namespace BML.Scripts
                         continue;
                     }
                     
-                    var spawnImmediate = _activeSpawnPointsByTag[kv.Key]
+                    var immediateSpawnPoints = _activeSpawnPointsByTag[kv.Key]
                         .Where(spawnPoint => spawnPoint.SpawnImmediate && !spawnPoint.Occupied && spawnPoint.SpawnChance > 0)
                         .OrderBy(spawnPoint => spawnPoint.EnemySpawnWeight);
 
-                    foreach (var spawnPoint in spawnImmediate)
+                    foreach (var spawnPoint in immediateSpawnPoints)
                     {            
-                        bool reachedGlobalSpawnCap1 = _currentEnemyCount.Value >= _enemySpawnerParams.SpawnCap;
-                        if (reachedGlobalSpawnCap1 && !spawnPoint.IgnoreGlobalSpawnCap)
+                        bool reachedGlobalSpawnCap = _currentEnemyCount.Value >= _enemySpawnerParams.SpawnCap;
+                        if (reachedGlobalSpawnCap && !spawnPoint.IgnoreGlobalSpawnCap)
                         {
                             continue;
                         }
                         
                         // Calculate random spawn position offset
-                        var randomOffset1 = Random.insideUnitCircle;
-                        var spawnPosition1 = spawnPoint.transform.position +
-                                            new Vector3(randomOffset1.x, 0f, randomOffset1.y) * enemyParamsForTag.SpawnRadiusOffset;
+                        var randomOffset = Random.insideUnitCircle;
+                        var spawnPosition = spawnPoint.transform.position +
+                                            new Vector3(randomOffset.x, 0f, randomOffset.y) * enemyParamsForTag.SpawnRadiusOffset;
                 
                         // Raycast from spawn position to place new game object along the level surface
                         // TODO why doesn't this use the spawn point projection function?
-                        Vector3 spawnPos1;
-                        var hitStableSurface1 = SpawnObjectsUtil.GetPointTowards(
-                            (spawnPosition1 - enemyParamsForTag.RaycastDirection * enemyParamsForTag.RaycastOffset),
+                        Vector3 spawnPos;
+                        var hitStableSurface = SpawnObjectsUtil.GetPointTowards(
+                            (spawnPosition - enemyParamsForTag.RaycastDirection * enemyParamsForTag.RaycastOffset),
                             enemyParamsForTag.RaycastDirection,
-                            out spawnPos1,
+                            out spawnPos,
                             _terrainLayerMask,
                             _maxRaycastLength);
                 
                         // Cancel spawn if did not find surface to spawn
-                        if (enemyParamsForTag.RequireStableSurface && !hitStableSurface1)
+                        if (enemyParamsForTag.RequireStableSurface && !hitStableSurface)
                         {
                             if (_enableLogs)
                                 Debug.LogWarning($"Failed to spawn {enemyParamsForTag.Prefab?.name}. No stable " +
@@ -482,7 +482,7 @@ namespace BML.Scripts
                         }
 
                         // Spawn chosen enemy at chosen spawn point
-                        var newEnemy1 = SpawnEnemy(spawnPos1, enemyParamsForTag, spawnPoint, spawnPoint.ParentNode,
+                        var newEnemy = SpawnEnemy(spawnPos, enemyParamsForTag, spawnPoint, spawnPoint.ParentNode,
                             !spawnPoint.IgnoreGlobalSpawnCap);
 
                         if (!spawnPoint.IgnoreGlobalSpawnCap)

--- a/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
+++ b/Assets/Scripts/EnemySpawner/EnemySpawnManager.cs
@@ -33,8 +33,6 @@ namespace BML.Scripts
         [SerializeField] private Transform _enemyContainer;
 
         [TitleGroup("Spawning Parameters")]
-        [SerializeField] private LayerMask _terrainLayerMask; // TODO remove deprecated
-        [Range(0f,100f), SerializeField] private float _maxRaycastLength = 10f;
         [SerializeField, Range(1, 10)] private int _despawnNodeDistance = 5;
         [SerializeField] private BoolVariable _isSpawningPaused;
         [SerializeField] private IntVariable _currentEnemyCount;

--- a/Assets/Scripts/EnemySpawner/EnemySpawnable.cs
+++ b/Assets/Scripts/EnemySpawner/EnemySpawnable.cs
@@ -21,9 +21,11 @@ namespace BML.Scripts
         public void Despawn()
         {
             _onDespawn?.Invoke();
-            
+
             if (SpawnPoint != null)
-                SpawnPoint.Occupied = false;
+            {
+                SpawnPoint.RecordEnemyDespawned();
+            }
             
             Destroy(this.gameObject);
         }
@@ -31,7 +33,9 @@ namespace BML.Scripts
         public void OnDeath()
         {
             if (SpawnPoint != null)
-                SpawnPoint.Occupied = false;
+            {
+                SpawnPoint.RecordEnemyDied();
+            }
         }
 
         #endregion

--- a/Assets/Scripts/EnemySpawner/EnemySpawnerParams.cs
+++ b/Assets/Scripts/EnemySpawner/EnemySpawnerParams.cs
@@ -21,14 +21,11 @@ namespace BML.Scripts
         public string Tag;
         public GameObject Prefab;
         public int Cost = 1;
-        [FoldoutGroup("Parameters")] public Vector3 RaycastDirection = Vector3.down; // TODO remove deprecated
-        [FoldoutGroup("Parameters")] public float RaycastOffset = 0f; // TODO remove deprecated
-        [FoldoutGroup("Parameters")] public float SpawnPosOffset = 0f; // TODO remove deprecated
+        [FoldoutGroup("Parameters")] public float SpawnPosOffset = 0f;
         [FoldoutGroup("Parameters")] public float SpawnRadiusOffset = .5f;
         [FoldoutGroup("Parameters")] public bool RequireStableSurface;
         [FoldoutGroup("Parameters")] public bool InstanceAsPrefab;
         [FoldoutGroup("Parameters")] public bool OccupySpawnPoint;
-        [FoldoutGroup("Parameters")] public bool SpawnInPlayerVistedRooms = true; // TODO remove deprecated
         [ReadOnly] public float NormalizedSpawnWeight;
     }
 }

--- a/Assets/Scripts/EnemySpawner/EnemySpawnerParams.cs
+++ b/Assets/Scripts/EnemySpawner/EnemySpawnerParams.cs
@@ -21,14 +21,14 @@ namespace BML.Scripts
         public string Tag;
         public GameObject Prefab;
         public int Cost = 1;
-        [FoldoutGroup("Parameters")] public Vector3 RaycastDirection = Vector3.down;
-        [FoldoutGroup("Parameters")] public float RaycastOffset = 0f;
-        [FoldoutGroup("Parameters")] public float SpawnPosOffset = 0f;
+        [FoldoutGroup("Parameters")] public Vector3 RaycastDirection = Vector3.down; // TODO remove deprecated
+        [FoldoutGroup("Parameters")] public float RaycastOffset = 0f; // TODO remove deprecated
+        [FoldoutGroup("Parameters")] public float SpawnPosOffset = 0f; // TODO remove deprecated
         [FoldoutGroup("Parameters")] public float SpawnRadiusOffset = .5f;
         [FoldoutGroup("Parameters")] public bool RequireStableSurface;
         [FoldoutGroup("Parameters")] public bool InstanceAsPrefab;
         [FoldoutGroup("Parameters")] public bool OccupySpawnPoint;
-        [FoldoutGroup("Parameters")] public bool SpawnInPlayerVistedRooms = true;
+        [FoldoutGroup("Parameters")] public bool SpawnInPlayerVistedRooms = true; // TODO remove deprecated
         [ReadOnly] public float NormalizedSpawnWeight;
     }
 }

--- a/Assets/Scripts/QuantumConsoleExtensions/EnemySpawnerCommands.cs
+++ b/Assets/Scripts/QuantumConsoleExtensions/EnemySpawnerCommands.cs
@@ -11,10 +11,24 @@ namespace BML.Scripts.QuantumConsoleExtensions
     public class EnemySpawnerCommands : MonoBehaviour
     {
         [SerializeField] private EnemySpawnManager _enemySpawnManager;
+        [SerializeField] private FloatVariable _intensityScore;
         [SerializeField] private FloatVariable _currentPercentToMaxSpawn;
         [SerializeField] private TransformSceneReference _playerTransformSceneReference;
 
         #region Commands
+
+        [Command("get-intensity", "Displays the current measurement of intensity with respect to what's currently happening to the player. This value is reactive to gameplay, not a set value.")]
+        private string GetIntensityScore()
+        {
+            return $"Intensity: {_intensityScore.Value}";
+        }
+        
+        [Command("set-intensity", "Displays the current measurement of intensity with respect to what's currently happening to the player. This value is reactive to gameplay, not a set value.")]
+        private string SetIntensityScore(float value)
+        {
+            _intensityScore.Value = value;
+            return "Set Intensity: {_intensityScore.Value} -> {value}";
+        }
         
         [Command("pause-spawning", "Pauses enemy spawning and difficulty curve.")]
         private void SetSpawningPaused(bool paused = true)


### PR DESCRIPTION
- Implement option for guaranteed enemy spawning when a spawn point becomes active.
- Fix order of death events, specifically EnemySpawnable.OnDeath
- Add option to continue normal enemy respawning after a point's "guaranteed" spawns are done.
- Rename variables.
- Deprecate EnemySpawnParams.SpawnInPlayerVisited in favor of the SpawnPoint._disableIfPlayerVisited implementation.
- Refactor enemy spawner to use projection behavior defined by each spawn point. Mark deprecated properties for removal.
- Organize spawn point inspector, add tooltips.
- Test enabling guaranteed spawns for all existing spawn points.
- Exclude "immediate" spawn points from normal spawning routine.
- Remove deprecated properties.
- Set guaranteed spawn points in the level to ignore global spawn cap. Implement OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns.
- Pick unweighted random enemy for immediate spawn when there are multiple options for the given tag.
- Disable "rotate toward surface normal" for bat spawn points.
- Update SpawnPoint.cs inspector.
- Add commands for intensity score.
- Only add guaranteed spawn points to the base large room prefab.
