### PR TITLE
Dev/ore

### DIFF
--- a/Assets/Entities/Bomb/Bomb.prefab
+++ b/Assets/Entities/Bomb/Bomb.prefab
@@ -493,10 +493,10 @@ MonoBehaviour:
     Variable: {fileID: 11400000, guid: deb0116f2dce187439f33946f472cc05, type: 2}
   _explosionMask:
     serializedVersion: 2
-    m_Bits: 4754624
+    m_Bits: 5803200
   _obstacleMask:
     serializedVersion: 2
-    m_Bits: 1048584
+    m_Bits: 8396808
   _damageType: 2
   _damage:
     UseConstant: 1

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Bat}.prefab
@@ -52,7 +52,8 @@ MonoBehaviour:
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
   _doInheritParentRotation: 1
-  _rotateTowardsSurfaceNormal: 0
+  _alignToProjectionVector: 0
+  _alignToSurfaceNormal: 0
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 1

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Enemy_Zombie}.prefab
@@ -52,7 +52,8 @@ MonoBehaviour:
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
   _doInheritParentRotation: 1
-  _rotateTowardsSurfaceNormal: 1
+  _alignToProjectionVector: 1
+  _alignToSurfaceNormal: 0
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
@@ -63,6 +64,7 @@ MonoBehaviour:
   _applySpawnLimitOnlyToGuaranteedSpawns: 0
   _ignoreGlobalSpawnCap: 0
   OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 0
+  _alertOnStart: 1
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Barrier}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Barrier}.prefab
@@ -44,7 +44,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4b5053bdbdbf48a09af720c08c3c8bf3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _projectionBehavior: 0
+  _projectionLayerMask:
+    serializedVersion: 2
+    m_Bits: 0
+  _projectionVector: {x: 0, y: -1, z: 0}
+  _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
+  _projectionDistance: 45
+  _doInheritParentRotation: 1
+  _alignToProjectionVector: 1
+  _alignToSurfaceNormal: 0
+  _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
+  _disableIfPlayerVisited: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 0
+  _limitToOneSpawnAtATime: 0
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _alertOnStart: 1
+  _showDebugPrefab: 0
+  _debugPrefab: {fileID: 0}
+  Occupied: 0
 --- !u!135 &667386773161420024
 SphereCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare_Start}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare_Start}.prefab
@@ -50,10 +50,21 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: -1, z: 0}
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
-  _rotateTowardsSurfaceNormal: 1
+  RequireStableSurface: 1
+  _doInheritParentRotation: 1
+  _alignToProjectionVector: 1
+  _alignToSurfaceNormal: 1
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
-  Occupied: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 0
+  _limitToOneSpawnAtATime: 0
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _alertOnStart: 1
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
+  Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare_Start}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare_Start}.prefab
@@ -55,6 +55,7 @@ MonoBehaviour:
   _alignToProjectionVector: 1
   _alignToSurfaceNormal: 1
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
+  _randomRotationRangeAroundUpAxis: {x: -180, y: 180}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
   _persistSpawns: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare}.prefab
@@ -50,10 +50,21 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: -1, z: 0}
   _projectionDirectionRandomnessRangeDegrees: {x: 30, y: 15}
   _projectionDistance: 45
-  _rotateTowardsSurfaceNormal: 1
+  RequireStableSurface: 1
+  _doInheritParentRotation: 1
+  _alignToProjectionVector: 1
+  _alignToSurfaceNormal: 1
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
-  Occupied: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 0
+  _limitToOneSpawnAtATime: 0
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _alertOnStart: 1
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
+  Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore_Rare}.prefab
@@ -55,6 +55,7 @@ MonoBehaviour:
   _alignToProjectionVector: 1
   _alignToSurfaceNormal: 1
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
+  _randomRotationRangeAroundUpAxis: {x: -180, y: 180}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
   _persistSpawns: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore}.prefab
@@ -50,6 +50,21 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: 0, z: 1}
   _projectionDirectionRandomnessRangeDegrees: {x: 60, y: 60}
   _projectionDistance: 8
+  RequireStableSurface: 1
+  _doInheritParentRotation: 1
+  _alignToProjectionVector: 1
+  _alignToSurfaceNormal: 1
+  _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 0
+  _limitToOneSpawnAtATime: 0
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _alertOnStart: 1
+  _showDebugPrefab: 0
+  _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Ore}.prefab
@@ -55,6 +55,7 @@ MonoBehaviour:
   _alignToProjectionVector: 1
   _alignToSurfaceNormal: 1
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
+  _randomRotationRangeAroundUpAxis: {x: -180, y: 180}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
   _persistSpawns: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Dart}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Dart}.prefab
@@ -50,6 +50,21 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: 0, z: 1}
   _projectionDirectionRandomnessRangeDegrees: {x: 60, y: 60}
   _projectionDistance: 8
+  RequireStableSurface: 0
+  _doInheritParentRotation: 1
+  _alignToProjectionVector: 1
+  _alignToSurfaceNormal: 0
+  _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 0
+  _limitToOneSpawnAtATime: 0
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _alertOnStart: 1
+  _showDebugPrefab: 0
+  _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Dart}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Dart}.prefab
@@ -52,7 +52,7 @@ MonoBehaviour:
   _projectionDistance: 8
   RequireStableSurface: 0
   _doInheritParentRotation: 1
-  _alignToProjectionVector: 1
+  _alignToProjectionVector: 0
   _alignToSurfaceNormal: 0
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Spike}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Spike}.prefab
@@ -51,10 +51,19 @@ MonoBehaviour:
   _projectionDirectionRandomnessRangeDegrees: {x: 60, y: 60}
   _projectionDistance: 8
   _doInheritParentRotation: 1
-  _rotateTowardsSurfaceNormal: 1
+  _alignToProjectionVector: 1
+  _alignToSurfaceNormal: 0
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
-  Occupied: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 0
+  _limitToOneSpawnAtATime: 0
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _alertOnStart: 1
   _showDebugPrefab: 0
   _debugPrefab: {fileID: 0}
+  Occupied: 0

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Spike}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Spike}.prefab
@@ -50,8 +50,9 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: 0, z: 0}
   _projectionDirectionRandomnessRangeDegrees: {x: 60, y: 60}
   _projectionDistance: 8
+  RequireStableSurface: 1
   _doInheritParentRotation: 1
-  _alignToProjectionVector: 1
+  _alignToProjectionVector: 0
   _alignToSurfaceNormal: 0
   _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1

--- a/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Stalactite}.prefab
+++ b/Assets/Entities/CaveGen/SpawnPoints/{Spawn_Trap_Stalactite}.prefab
@@ -50,7 +50,20 @@ MonoBehaviour:
   _projectionVector: {x: 0, y: 1, z: 0}
   _projectionDirectionRandomnessRangeDegrees: {x: 60, y: 60}
   _projectionDistance: 8
-  _rotateTowardsSurfaceNormal: 0
+  _doInheritParentRotation: 1
+  _alignToProjectionVector: 0
+  _alignToSurfaceNormal: 0
+  _rotationEulerOffset: {x: 0, y: 0, z: 0}
   _startingSpawnChance: 1
   _disableIfPlayerVisited: 0
+  _persistSpawns: 0
+  _guaranteeSpawnIfInRange: 0
+  _limitToOneSpawnAtATime: 0
+  _spawnLimit: -1
+  _applySpawnLimitOnlyToGuaranteedSpawns: 0
+  _ignoreGlobalSpawnCap: 0
+  OnlyIgnoreGlobalSpawnCapForGuaranteedSpawns: 1
+  _alertOnStart: 1
+  _showDebugPrefab: 0
+  _debugPrefab: {fileID: 0}
   Occupied: 0

--- a/Assets/Entities/Enemy/BombEnemy/BombEnemy.prefab
+++ b/Assets/Entities/Enemy/BombEnemy/BombEnemy.prefab
@@ -13909,10 +13909,10 @@ MonoBehaviour:
     Variable: {fileID: 11400000, guid: deb0116f2dce187439f33946f472cc05, type: 2}
   _explosionMask:
     serializedVersion: 2
-    m_Bits: 33984
+    m_Bits: 1082560
   _obstacleMask:
     serializedVersion: 2
-    m_Bits: 1048576
+    m_Bits: 8396808
   _damageType: 2048
   _damage:
     UseConstant: 1

--- a/Assets/Entities/Enemy/OreMimicEnemy/OreMimicEnemy.prefab
+++ b/Assets/Entities/Enemy/OreMimicEnemy/OreMimicEnemy.prefab
@@ -652,8 +652,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2008487833729850768}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.14300004, z: 0.6769528}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.14300026, z: 0.6769513}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7410978460943021293}
@@ -792,105 +792,12 @@ MonoBehaviour:
   - id: 1
   - id: 2
   - id: 3
-  - id: 4
   KeepPlayModeChanges: 0
   PerformanceMode: 0
   ForceStopFeedbacksOnDisable: 1
   references:
     version: 1
     00000000:
-      type: {class: MMF_Events, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks}
-      data:
-        Active: 1
-        UniqueID: -2042942254
-        Label: Unity Events
-        ChannelMode: 0
-        Channel: 0
-        MMChannelDefinition: {fileID: 0}
-        Chance: 100
-        DisplayColor: {r: 0, g: 0, b: 0, a: 1}
-        Timing:
-          TimescaleMode: 0
-          ExcludeFromHoldingPauses: 0
-          ContributeToTotalDuration: 1
-          InitialDelay: 0
-          CooldownDuration: 0
-          InterruptsOnStop: 1
-          NumberOfRepeats: 0
-          RepeatForever: 0
-          DelayBetweenRepeats: 1
-          MMFeedbacksDirectionCondition: 0
-          PlayDirection: 0
-          ConstantIntensity: 0
-          UseIntensityInterval: 0
-          IntensityIntervalMin: 0
-          IntensityIntervalMax: 0
-          Sequence: {fileID: 0}
-          TrackID: 0
-          Quantized: 0
-          TargetBPM: 120
-        AutomatedTargetAcquisition:
-          Mode: 0
-          ChildIndex: 0
-        RandomizeOutput: 0
-        RandomMultiplier: {x: 0.8, y: 1}
-        RandomizeDuration: 0
-        RandomDurationMultiplier: {x: 0.5, y: 2}
-        UseRange: 0
-        RangeDistance: 5
-        UseRangeFalloff: 0
-        RangeFalloff:
-          serializedVersion: 2
-          m_Curve:
-          - serializedVersion: 3
-            time: 0
-            value: 1
-            inSlope: 0
-            outSlope: 0
-            tangentMode: 0
-            weightedMode: 0
-            inWeight: 0
-            outWeight: 0
-          - serializedVersion: 3
-            time: 1
-            value: 0
-            inSlope: 0
-            outSlope: 0
-            tangentMode: 0
-            weightedMode: 0
-            inWeight: 0
-            outWeight: 0
-          m_PreInfinity: 2
-          m_PostInfinity: 2
-          m_RotationOrder: 4
-        RemapRangeFalloff: {x: 0, y: 1}
-        Owner: {fileID: 3439596409321352460}
-        DebugActive: 0
-        PlayEvents:
-          m_PersistentCalls:
-            m_Calls:
-            - m_Target: {fileID: 412785362129381577}
-              m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
-              m_MethodName: PlayFeedbacks
-              m_Mode: 1
-              m_Arguments:
-                m_ObjectArgument: {fileID: 0}
-                m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-                m_IntArgument: 0
-                m_FloatArgument: 0
-                m_StringArgument: 
-                m_BoolArgument: 0
-              m_CallState: 2
-        StopEvents:
-          m_PersistentCalls:
-            m_Calls: []
-        InitializationEvents:
-          m_PersistentCalls:
-            m_Calls: []
-        ResetEvents:
-          m_PersistentCalls:
-            m_Calls: []
-    00000001:
       type: {class: MMF_Scale, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks}
       data:
         Active: 1
@@ -1307,7 +1214,7 @@ MonoBehaviour:
           m_PreInfinity: 2
           m_PostInfinity: 2
           m_RotationOrder: 4
-    00000002:
+    00000001:
       type: {class: MMF_Pause, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks}
       data:
         Active: 1
@@ -1383,7 +1290,7 @@ MonoBehaviour:
         ScriptDriven: 0
         AutoResume: 0
         AutoResumeAfter: 0.25
-    00000003:
+    00000002:
       type: {class: BMLInstantiateProjectile, ns: BML.Scripts.MMFFeedbacks, asm: BML.Scripts}
       data:
         Active: 1
@@ -1465,7 +1372,7 @@ MonoBehaviour:
         CreateObjectPool: 0
         ObjectPoolSize: 5
         MutualizePools: 0
-    00000004:
+    00000003:
       type: {class: BMLSoundManagerSound, ns: BML.Scripts.MMFFeedbacks, asm: BML.Scripts}
       data:
         Active: 1
@@ -2310,7 +2217,7 @@ MonoBehaviour:
           Initialized: 1
         RemapCurveZero: 0
         RemapCurveZeroAlt: 0
-        RemapCurveOne: 1.5
+        RemapCurveOne: 1.2
         RemapCurveOneAlt: 1
         AnimateX: 0
         AnimatePositionTweenX:
@@ -2745,14 +2652,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7410978460943021292}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.753, z: 0}
-  m_LocalScale: {x: 0.5215591, y: 1.3327115, z: 0.5215591}
+  m_LocalPosition: {x: 0, y: -0.53999996, z: 0}
+  m_LocalScale: {x: 0.85975224, y: 0.78505415, z: 0.85975224}
   m_Children:
   - {fileID: 8831013573816406865}
   - {fileID: 7137367407479230526}
   - {fileID: 342207017903563309}
   - {fileID: 9154818587218600943}
-  m_Father: {fileID: 7410978462104228994}
+  m_Father: {fileID: 194073441436119326}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &7410978460943021287
@@ -3157,7 +3064,7 @@ MonoBehaviour:
           Initialized: 1
         RemapCurveZero: 0
         RemapCurveZeroAlt: 0
-        RemapCurveOne: 1.5
+        RemapCurveOne: 1.2
         RemapCurveOneAlt: 1
         AnimateX: 0
         AnimatePositionTweenX:
@@ -4679,8 +4586,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 6992104097043134732}
-  - {fileID: 7410978460943021293}
+  - {fileID: 194073441436119326}
   - {fileID: 7410978462301342903}
   m_Father: {fileID: 6737921894081688991}
   m_RootOrder: 0
@@ -4714,7 +4620,7 @@ Transform:
   m_Children:
   - {fileID: 6572962962027215494}
   m_Father: {fileID: 7410978462104228994}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8054940693936190109
 GameObject:
@@ -4823,15 +4729,15 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8076651376206212715}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.351, z: 0.281}
-  m_LocalScale: {x: 0.13529354, y: 0.19936939, z: 0.16557114}
+  m_LocalPosition: {x: 0, y: -0.37418264, z: 0.4659418}
+  m_LocalScale: {x: 0.22302154, y: 0.32864586, z: 0.272932}
   m_Children:
   - {fileID: 1015484148625425433}
   - {fileID: 7924680262567895713}
   - {fileID: 1100061481535802472}
   - {fileID: 823132115736365452}
   - {fileID: 4895991131820659476}
-  m_Father: {fileID: 7410978462104228994}
+  m_Father: {fileID: 194073441436119326}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &4492471101260114746
@@ -4883,6 +4789,38 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8263888989242150315
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 194073441436119326}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &194073441436119326
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8263888989242150315}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.03, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6992104097043134732}
+  - {fileID: 7410978460943021293}
+  m_Father: {fileID: 7410978462104228994}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &4230764367346052056
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4974,10 +4912,6 @@ PrefabInstance:
       propertyPath: FeedbacksList.Array.data[0].Offset.y
       value: 0.1
       objectReference: {fileID: 0}
-    - target: {fileID: 4543063158091760401, guid: ba862138d6619bd449650baaad4863f3, type: 3}
-      propertyPath: FeedbacksList.Array.data[0].BoundRenderers.Array.data[0]
-      value: 
-      objectReference: {fileID: 7410978460943021286}
     - target: {fileID: 5626101586822741521, guid: ba862138d6619bd449650baaad4863f3, type: 3}
       propertyPath: m_RootOrder
       value: 1
@@ -5202,21 +5136,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8084968094344954568, guid: ba862138d6619bd449650baaad4863f3, type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
     - target: {fileID: 8180624774006092877, guid: ba862138d6619bd449650baaad4863f3, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ba862138d6619bd449650baaad4863f3, type: 3}
---- !u!1 &26064794837490706 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4245249631717701578, guid: ba862138d6619bd449650baaad4863f3, type: 3}
-  m_PrefabInstance: {fileID: 4230764367346052056}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &454463660852375007 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4393302721342948871, guid: ba862138d6619bd449650baaad4863f3, type: 3}
@@ -5228,11 +5153,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &5418352780063416213 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8180624774006092877, guid: ba862138d6619bd449650baaad4863f3, type: 3}
-  m_PrefabInstance: {fileID: 4230764367346052056}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2178319890112613326 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2633554240158441494, guid: ba862138d6619bd449650baaad4863f3, type: 3}
@@ -5260,17 +5180,16 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7437511740362481223, guid: ba862138d6619bd449650baaad4863f3, type: 3}
   m_PrefabInstance: {fileID: 4230764367346052056}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &412785362129381577 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4543063158091760401, guid: ba862138d6619bd449650baaad4863f3, type: 3}
+--- !u!1 &26064794837490706 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4245249631717701578, guid: ba862138d6619bd449650baaad4863f3, type: 3}
   m_PrefabInstance: {fileID: 4230764367346052056}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+--- !u!4 &5418352780063416213 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8180624774006092877, guid: ba862138d6619bd449650baaad4863f3, type: 3}
+  m_PrefabInstance: {fileID: 4230764367346052056}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4571825172730824089
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5384,7 +5303,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7379165262754171365, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: uniqueID
-      value: 7107131155565000448
+      value: 332066088659607566
       objectReference: {fileID: 0}
     - target: {fileID: 7446825106882959702, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -5508,14 +5427,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
---- !u!135 &7404837528725607688 stripped
-SphereCollider:
-  m_CorrespondingSourceObject: {fileID: 6462989521983410321, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+--- !u!1 &6572962962027215512 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7225383730169331457, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4571825172730824089}
   m_PrefabAsset: {fileID: 0}
---- !u!64 &4466289593536763687 stripped
-MeshCollider:
-  m_CorrespondingSourceObject: {fileID: 182695390771352254, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+--- !u!4 &6572962962027215494 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7225383730169331487, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4571825172730824089}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &6137574798445879084 stripped
@@ -5529,14 +5448,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d126ea3a59c2c144acee767a06eed81, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &6572962962027215494 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7225383730169331487, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+--- !u!64 &4466289593536763687 stripped
+MeshCollider:
+  m_CorrespondingSourceObject: {fileID: 182695390771352254, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4571825172730824089}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &6572962962027215512 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7225383730169331457, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+--- !u!135 &7404837528725607688 stripped
+SphereCollider:
+  m_CorrespondingSourceObject: {fileID: 6462989521983410321, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4571825172730824089}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &5431843965152438172

--- a/Assets/Entities/Ore/CommonRock/Ore_BarrierNew.mat
+++ b/Assets/Entities/Ore/CommonRock/Ore_BarrierNew.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Ore_CommonNew
+  m_Name: Ore_BarrierNew
   m_Shader: {fileID: 4800000, guid: 835721fa6edc42543a9793e37ba98b5a, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 0
@@ -61,11 +61,14 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Floats:
     - _BumpScale: 1
+    - _CritCrackSize: 0.05
+    - _CritCrackSizeLarge: 0.05
+    - _CritCrackSizeSmall: 0.05
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _EdgeLength: 15
-    - _Float2: -0.3
+    - _Float2: 0
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
@@ -77,7 +80,7 @@ Material:
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
-    - _VoronoiScale: 5
+    - _VoronoiScale: 7
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:

--- a/Assets/Entities/Ore/CommonRock/Ore_BarrierNew.mat
+++ b/Assets/Entities/Ore/CommonRock/Ore_BarrierNew.mat
@@ -64,10 +64,12 @@ Material:
     - _CritCrackSize: 0.05
     - _CritCrackSizeLarge: 0.05
     - _CritCrackSizeSmall: 0.05
+    - _CritCracksSpread: 0.04
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _EdgeLength: 15
+    - _EmissionStrength: 10
     - _Float2: 0
     - _GlossMapScale: 1
     - _Glossiness: 0.5
@@ -76,6 +78,7 @@ Material:
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _Seed: 0
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1

--- a/Assets/Entities/Ore/CommonRock/Ore_BarrierNew.mat.meta
+++ b/Assets/Entities/Ore/CommonRock/Ore_BarrierNew.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9445ff0a02739e84ab1e58fe864d30ad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/CommonRock/Ore_Common.prefab
+++ b/Assets/Entities/Ore/CommonRock/Ore_Common.prefab
@@ -7,6 +7,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 124687947047603566, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 182695390771352254, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -15,6 +19,10 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 771399382741072669, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -8626944733999078677, guid: 6e9de6aeaa9c0464d8df44a2f8e44709, type: 3}
     - target: {fileID: 1170534869451340434, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -131,18 +139,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -31.388
       objectReference: {fileID: 0}
-    - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: FeedbacksList.Array.data[1].Active
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472804554480619527, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.438
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472804554480619527, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.002
-      objectReference: {fileID: 0}
+    - target: {fileID: 4924632540137295336, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -8626944733999078677, guid: 6e9de6aeaa9c0464d8df44a2f8e44709, type: 3}
     - target: {fileID: 5289639138145682280, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_IsActive
       value: 0

--- a/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
+++ b/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
@@ -11,7 +11,7 @@ Material:
   m_Shader: {fileID: 4800000, guid: 835721fa6edc42543a9793e37ba98b5a, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 0
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
@@ -80,13 +80,15 @@ Material:
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:
-    - _Albedo: {r: 0.5566037, g: 0.40880087, b: 0.25992346, a: 1}
+    - _Albedo: {r: 0.5566037, g: 0.4088008, b: 0.2599234, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _CrackAlbedo: {r: 0.47499996, g: 0.34788728, b: 0.22077465, a: 1}
+    - _CrackAlbedo: {r: 0.44705883, g: 0.3254902, b: 0.20784314, a: 1}
     - _CrackLightness: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 1}
     - _CrackPosition0: {r: 0, g: 0, b: 0, a: 0}
     - _CrackPosition1: {r: 0, g: 0, b: 0, a: 0}
+    - _CrackPosition2: {r: 0, g: 0, b: 0, a: 0}
     - _CritPosition: {r: 0, g: 0, b: 0, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Vector1: {r: 0, g: 0, b: 0, a: 0}
+    - _VignetteAlignment: {r: 0, g: 1, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
+++ b/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
@@ -61,10 +61,12 @@ Material:
         m_Offset: {x: 0, y: 0}
     m_Floats:
     - _BumpScale: 1
+    - _CritCracksSpread: 0.05
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _EdgeLength: 15
+    - _EmissionStrength: 15
     - _Float2: -0.3
     - _GlossMapScale: 1
     - _Glossiness: 0.5

--- a/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
+++ b/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
@@ -7,11 +7,11 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Mat_Ore_Base
-  m_Shader: {fileID: 4800000, guid: aa54248563f1ba6488ee180ee652807b, type: 3}
+  m_Name: Ore_CommonNew
+  m_Shader: {fileID: 4800000, guid: 835721fa6edc42543a9793e37ba98b5a, type: 3}
   m_ShaderKeywords: 
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 1
+  m_LightmapFlags: 0
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
@@ -55,25 +55,21 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _texcoord:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     m_Floats:
     - _BumpScale: 1
-    - _CrackScale: 1.7
-    - _CrackStrengthFactor: 0
     - _Cutoff: 0.5
-    - _DebugVertexCrack: 0
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
-    - _Float1: 0.2
-    - _Float2: -1.86
-    - _Float3: -9.53
+    - _EdgeLength: 15
+    - _Float2: -0.3
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
-    - _MaxCrackStrength: 2.5
-    - _MaxVertexCrackStrength: -1
-    - _Metallic: 0.5
-    - _MinCrackStrength: 0.5
-    - _MinVertexCrackStrength: 0
+    - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
@@ -81,15 +77,16 @@ Material:
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
-    - _VertexCrackScale: 0.36
-    - _VertexCrackStrengthFactor: 0
-    - _VertexCrackThickness: 0.26
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:
-    - _Albedo: {r: 0.36792445, g: 0.36792445, b: 0.36792445, a: 1}
-    - _CenterOffset: {r: -0.26, g: -0.81, b: 0, a: 0}
-    - _Color: {r: 0.38679248, g: 0.38679248, b: 0.38679248, a: 1}
-    - _CrackAlbedo: {r: 0.23399994, g: 0.23399994, b: 0.23399994, a: 1}
+    - _Albedo: {r: 0.5566037, g: 0.40880087, b: 0.25992346, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _CrackAlbedo: {r: 0.47499996, g: 0.34788728, b: 0.22077465, a: 1}
+    - _CrackLightness: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 1}
+    - _CrackPosition0: {r: 0, g: 0, b: 0, a: 0}
+    - _CrackPosition1: {r: 0, g: 0, b: 0, a: 0}
+    - _CritPosition: {r: 0, g: 0, b: 0, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Vector1: {r: 0, g: 0, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
+++ b/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat
@@ -80,15 +80,16 @@ Material:
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:
-    - _Albedo: {r: 0.5372549, g: 0.4632539, b: 0.3825255, a: 1}
+    - _Albedo: {r: 0.794, g: 0.7201173, b: 0.642346, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _CrackAlbedo: {r: 0.36078432, g: 0.3237438, b: 0.28141177, a: 1}
+    - _CrackAlbedo: {r: 0.595, g: 0.53679353, b: 0.4656522, a: 1}
     - _CrackLightness: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 1}
     - _CrackPosition0: {r: 0, g: 0, b: 0, a: 0}
     - _CrackPosition1: {r: 0, g: 0, b: 0, a: 0}
     - _CrackPosition2: {r: 0, g: 0, b: 0, a: 0}
     - _CritPosition: {r: 0, g: 0, b: 0, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Vector0: {r: 0, g: 0, b: 0, a: 0}
     - _Vector1: {r: 0, g: 0, b: 0, a: 0}
     - _VignetteAlignment: {r: 0, g: 1, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat.meta
+++ b/Assets/Entities/Ore/CommonRock/Ore_CommonNew.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5f0f062f3b77894ebb415a638bffa42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
+++ b/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
@@ -1128,14 +1128,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
---- !u!23 &1856003839198373565 stripped
-MeshRenderer:
-  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
-  m_PrefabInstance: {fileID: 1008889919471139385}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &198481471302895464 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+  m_PrefabInstance: {fileID: 1008889919471139385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &1856003839198373565 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
   m_PrefabInstance: {fileID: 1008889919471139385}
   m_PrefabAsset: {fileID: 0}
 --- !u!64 &6924033394497364990
@@ -1380,7 +1380,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   version: 1
-  uniqueID: 9166457781507022210
+  uniqueID: 5426137498125315592
   updateError: 1
   checkTime: 0.2
 --- !u!114 &8438481402473190015
@@ -1397,7 +1397,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _health: {fileID: 6287322958753863177}
   _critMarkerTransform: {fileID: 4193293445037692976}
-  _renderer: {fileID: 1856003839198373565}
+  _oreRenderer: {fileID: 1856003839198373565}
+  _oreCrystalsRenderer: {fileID: 2856514282252951559}
 --- !u!1001 &2413171799035776128
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2982,108 +2983,15 @@ PrefabInstance:
       value: -0.7076672
       objectReference: {fileID: 0}
     - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
       objectReference: {fileID: 8438481402473190015}
-    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: UpdateShaderOnPickaxeInteract
-      objectReference: {fileID: 0}
-    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: BML.Scripts.OreShaderController, BML.Scripts
-      objectReference: {fileID: 0}
-    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 8885816528984506916, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
---- !u!114 &8537203387600411174 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5432566915175241370, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e2fe64b9028caa84a8a9952a1342dbbd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1365119649482718702 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3454127850065686866, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &6889627277849608047 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7098438743458149331, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bb817c89909b4b2095d4fc1a3f8f2a5f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1070838779823517863 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3729549894264273947, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b2f680a7afde40b49d9741bdbc7aa5bd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &4226404105143900442 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &5783869688381910301 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7879620644554891681, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2454297925495668044 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2238584893062115824, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &4193293445037692976 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 517902721090737292, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &6438986197002974141 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7225383730169331457, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2242044947178572222 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2450872905461499138, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
@@ -3116,6 +3024,80 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3454127850101988319, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4404071749740678332}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8537203387600411174 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5432566915175241370, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2fe64b9028caa84a8a9952a1342dbbd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!23 &2856514282252951559 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: 1925859997282217147, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &4226404105143900442 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1365119649482718702 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3454127850065686866, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1070838779823517863 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3729549894264273947, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2f680a7afde40b49d9741bdbc7aa5bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &5783869688381910301 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7879620644554891681, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2454297925495668044 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2238584893062115824, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &4193293445037692976 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 517902721090737292, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6438986197002974141 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7225383730169331457, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6889627277849608047 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7098438743458149331, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb817c89909b4b2095d4fc1a3f8f2a5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &7463206702865767283
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
+++ b/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
@@ -1117,7 +1117,7 @@ PrefabInstance:
     - target: {fileID: -7511558181221131132, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
-      objectReference: {fileID: 2100000, guid: a5f0f062f3b77894ebb415a638bffa42, type: 2}
+      objectReference: {fileID: 2100000, guid: 9445ff0a02739e84ab1e58fe864d30ad, type: 2}
     - target: {fileID: 919132149155446097, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_Name
       value: Ore_Barrier.001
@@ -2346,15 +2346,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4472804554480619527, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4472804554480619527, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.19
+      value: 1.41
       objectReference: {fileID: 0}
     - target: {fileID: 4472804554480619527, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.29
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4598055283801037930, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh

--- a/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
+++ b/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
@@ -1063,6 +1063,316 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 10ef57ca79f39aa4fb53200ff459ad4b, type: 3}
+--- !u!1001 &1008889919471139385
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4226404105143900442}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.50008726
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.49991274
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.50008726
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49991274
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -89.98
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a5f0f062f3b77894ebb415a638bffa42, type: 2}
+    - target: {fileID: 919132149155446097, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_Name
+      value: Ore_Barrier.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+--- !u!23 &1856003839198373565 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+  m_PrefabInstance: {fileID: 1008889919471139385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &198481471302895464 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+  m_PrefabInstance: {fileID: 1008889919471139385}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &6924033394497364990
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198481471302895464}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 764190037039818589, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
+--- !u!114 &2663340801523199170
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198481471302895464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96e5457f6d8871d4a9d6dc9518bc622e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 11400000, guid: 1d18a3528e56519478ac9fb768afcc25, type: 2}
+        m_TargetAssemblyTypeName: BML.ScriptableObjectCore.Scripts.Events.GameEvent,
+          ScriptableObjectSystem
+        m_MethodName: Raise
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  _onPickaxeInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8537203387600411174}
+        m_TargetAssemblyTypeName: BML.Scripts.Damageable, BML.Scripts
+        m_MethodName: TakeDamage
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 2242044947178572222}
+        m_TargetAssemblyTypeName: BML.Scripts.OreCritMarker, BML.Scripts
+        m_MethodName: ActivateCritMarker
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  _onPickaxeSecondaryInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 8537203387600411174}
+        m_TargetAssemblyTypeName: BML.Scripts.Damageable, BML.Scripts
+        m_MethodName: TakeDamage
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4209211229920923481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198481471302895464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2fe64b9028caa84a8a9952a1342dbbd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: {fileID: 6287322958753863177}
+  _damageable:
+  - _damageTypesPreview: Player_Pickaxe, Player_Bomb, Enemy_Sentinel_Projectile,
+      Enemy_Mimic_Projectile, Ore_Explosive, Enemy_Snake_Projectile, Player_Pickaxe_Secondary,
+      Enemy_Bomb_Explosion, Trap_Stalactite, Enemy_Worm
+    _damageType: 28115
+    _damageModifierType: 0
+    _damageMultiplier:
+      ReferenceTypeSelector: 0
+      ConstantValue: 1
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageResistance:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageOverride:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _onDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onFailDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onDeath:
+      m_PersistentCalls:
+        m_Calls: []
+  - _damageTypesPreview: Trap_Spike
+    _damageType: 4096
+    _damageModifierType: 2
+    _damageMultiplier:
+      ReferenceTypeSelector: 0
+      ConstantValue: 1
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageResistance:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageOverride:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _onDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onFailDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onDeath:
+      m_PersistentCalls:
+        m_Calls: []
+  _onDamage:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6889627277849608047}
+        m_TargetAssemblyTypeName: BML.Scripts.MoveToHitPositon, BML.Scripts
+        m_MethodName: Move
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1365119649482718702}
+        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+        m_MethodName: PlayFeedbacks
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &4320882658494234174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198481471302895464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 183748dd497aa473a98ff0cd8cb67fc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  uniqueID: 359972591828912678
+  updateError: 1
+  checkTime: 0.2
+--- !u!114 &8438481402473190015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198481471302895464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45fc6fa940a34d65adfcefad774e38d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _health: {fileID: 6287322958753863177}
+  _renderer: {fileID: 1856003839198373565}
 --- !u!1001 &2413171799035776128
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1496,6 +1806,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 124687947047603566, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 124687947047603566, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 182695390771352254, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -1567,6 +1885,18 @@ PrefabInstance:
     - target: {fileID: 530843240281542563, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 624321465927530347, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -1840,9 +2170,17 @@ PrefabInstance:
       propertyPath: _miningEnemyAlertRadius.Variable
       value: 
       objectReference: {fileID: 11400000, guid: 00ee930cc9b8c2141a4b17e1dc9c7a6c, type: 2}
+    - target: {fileID: 2722295034177052522, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3152966374852885436, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3454127850101988312, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3454127850101988316, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -1974,7 +2312,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4472804554480619527, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4472804554480619527, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2055,6 +2393,10 @@ PrefabInstance:
     - target: {fileID: 4636054497774908171, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5289639138145682280, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5289639138145682280, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_IsActive
@@ -2244,7 +2586,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7379165262754171365, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: uniqueID
-      value: 6719671107306671918
+      value: 8568011193949762089
+      objectReference: {fileID: 0}
+    - target: {fileID: 7379165262754171365, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7446825106882959702, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -2526,9 +2872,21 @@ PrefabInstance:
       propertyPath: m_Tangents.Array.data[14].z
       value: -0.7076672
       objectReference: {fileID: 0}
+    - target: {fileID: 8144536734678889990, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8589218789292955658, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697510868860655863, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8697510868860655863, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8702343123064201410, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -2600,37 +2958,39 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
---- !u!1 &6438986197002974141 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7225383730169331457, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &6287322958753863177 stripped
+--- !u!114 &8537203387600411174 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7664960571339365045, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_CorrespondingSourceObject: {fileID: 5432566915175241370, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4404071749740678332}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6438986197002974141}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d126ea3a59c2c144acee767a06eed81, type: 3}
+  m_Script: {fileID: 11500000, guid: e2fe64b9028caa84a8a9952a1342dbbd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1365119649539987299 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3454127850101988319, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+--- !u!114 &1365119649482718702 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3454127850065686866, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4404071749740678332}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &5783869688381910301 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7879620644554891681, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6889627277849608047 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7098438743458149331, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4404071749740678332}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &1365119649122788791 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3454127850225854731, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 4404071749740678332}
-  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb817c89909b4b2095d4fc1a3f8f2a5f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1070838779823517863 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3729549894264273947, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
@@ -2642,9 +3002,56 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2f680a7afde40b49d9741bdbc7aa5bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &4226404105143900442 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &5783869688381910301 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7879620644554891681, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2454297925495668044 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2238584893062115824, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6438986197002974141 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7225383730169331457, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2242044947178572222 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2450872905461499138, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6438986197002974141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e04cd80442130c41a74a36c671de6e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6287322958753863177 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7664960571339365045, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6438986197002974141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d126ea3a59c2c144acee767a06eed81, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1365119649122788791 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3454127850225854731, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1365119649539987299 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3454127850101988319, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4404071749740678332}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &7463206702865767283

--- a/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
+++ b/Assets/Entities/Ore/ExitOre/Ore_ExitBarrier.prefab
@@ -1088,27 +1088,27 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.50008726
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.49991274
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.50008726
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.49991274
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -1149,7 +1149,7 @@ MeshCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 4
-  m_Convex: 0
+  m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: 764190037039818589, guid: b735b187c3daa21469dd9edb1342f1c4, type: 3}
 --- !u!114 &2663340801523199170
@@ -1207,12 +1207,36 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 8438481402473190015}
+        m_TargetAssemblyTypeName: BML.Scripts.OreShaderController, BML.Scripts
+        m_MethodName: UpdateShaderOnPickaxeInteract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   _onPickaxeSecondaryInteract:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 8537203387600411174}
         m_TargetAssemblyTypeName: BML.Scripts.Damageable, BML.Scripts
         m_MethodName: TakeDamage
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 8438481402473190015}
+        m_TargetAssemblyTypeName: BML.Scripts.OreShaderController, BML.Scripts
+        m_MethodName: UpdateShaderOnPickaxeInteract
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1356,7 +1380,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   version: 1
-  uniqueID: 359972591828912678
+  uniqueID: 9166457781507022210
   updateError: 1
   checkTime: 0.2
 --- !u!114 &8438481402473190015
@@ -1372,6 +1396,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _health: {fileID: 6287322958753863177}
+  _critMarkerTransform: {fileID: 4193293445037692976}
   _renderer: {fileID: 1856003839198373565}
 --- !u!1001 &2413171799035776128
 PrefabInstance:
@@ -2158,6 +2183,10 @@ PrefabInstance:
       propertyPath: m_Tangents.Array.data[14].z
       value: -0.7076672
       objectReference: {fileID: 0}
+    - target: {fileID: 2450872905461499138, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _oreCollider
+      value: 
+      objectReference: {fileID: 6924033394497364990}
     - target: {fileID: 2450872905461499138, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: _critMarkerMinMaxAngle.x
       value: 4.6647825
@@ -2952,6 +2981,34 @@ PrefabInstance:
       propertyPath: m_Tangents.Array.data[14].z
       value: -0.7076672
       objectReference: {fileID: 0}
+    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 8438481402473190015}
+    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: UpdateShaderOnPickaxeInteract
+      objectReference: {fileID: 0}
+    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: BML.Scripts.OreShaderController, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 8720461623094003360, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 8885816528984506916, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -3015,6 +3072,11 @@ Transform:
 --- !u!1 &2454297925495668044 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2238584893062115824, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 4404071749740678332}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &4193293445037692976 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 517902721090737292, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 4404071749740678332}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &6438986197002974141 stripped

--- a/Assets/Entities/Ore/ExplosiveOre/Ore_Explosive.prefab
+++ b/Assets/Entities/Ore/ExplosiveOre/Ore_Explosive.prefab
@@ -844,43 +844,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.0699634
+      value: -0.007090522
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.72303224
+      value: 0.184
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.116959564
+      value: 0.00021604076
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.54047906
+      value: -0.74650115
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.025198596
+      value: 0.19060029
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.83925897
+      value: 0.6367566
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.053776387
+      value: 0.03079981
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -6.748
+      value: -18.892
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 245.617
+      value: 277.068
       objectReference: {fileID: 0}
     - target: {fileID: 8943904743306501518, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.914
+      value: 12.002
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1693e39c988f211489b6fc48aab5ea77, type: 3}

--- a/Assets/Entities/Ore/ExplosiveOre/Ore_Explosive.prefab
+++ b/Assets/Entities/Ore/ExplosiveOre/Ore_Explosive.prefab
@@ -1017,7 +1017,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 517902721090737292, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 530843240281542563, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -1486,6 +1486,10 @@ PrefabInstance:
     - target: {fileID: 3152966374852885436, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3454127850225854731, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: FeedbacksList.Array.data[1].PlayEvents.m_PersistentCalls.m_Calls.Array.size
@@ -2456,6 +2460,10 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 8980370900830688701, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
 --- !u!1 &8824840477864719383 stripped
@@ -2553,10 +2561,10 @@ MonoBehaviour:
     Variable: {fileID: 11400000, guid: deb0116f2dce187439f33946f472cc05, type: 2}
   _explosionMask:
     serializedVersion: 2
-    m_Bits: 33984
+    m_Bits: 1082560
   _obstacleMask:
     serializedVersion: 2
-    m_Bits: 1048576
+    m_Bits: 8396808
   _damageType: 128
   _damage:
     UseConstant: 1

--- a/Assets/Entities/Ore/Mat_OreCrystalNew.mat
+++ b/Assets/Entities/Ore/Mat_OreCrystalNew.mat
@@ -7,11 +7,11 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Ore_CommonNew
-  m_Shader: {fileID: 4800000, guid: 835721fa6edc42543a9793e37ba98b5a, type: 3}
+  m_Name: Mat_OreCrystalNew
+  m_Shader: {fileID: 4800000, guid: 1df71dc43c1ae464a80657ff347370b0, type: 3}
   m_ShaderKeywords: 
-  m_LightmapFlags: 0
-  m_EnableInstancingVariants: 1
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
@@ -62,17 +62,23 @@ Material:
     m_Floats:
     - _BumpScale: 1
     - _Cutoff: 0.5
+    - _DamageFac: 0
+    - _DamageInsetMultiplier: -0.14
+    - _DamageMax: -0.18
+    - _DamageScaleMultiplier: -0.05
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
     - _EdgeLength: 15
-    - _Float2: -0.3
+    - _Float0: -0.03
+    - _Float1: 0
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
-    - _Metallic: 0
+    - _Metallic: 0.5
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _SmoothnessMetallic: 0.383
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
@@ -80,15 +86,8 @@ Material:
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:
-    - _Albedo: {r: 0.5372549, g: 0.4632539, b: 0.3825255, a: 1}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _CrackAlbedo: {r: 0.36078432, g: 0.3237438, b: 0.28141177, a: 1}
-    - _CrackLightness: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 1}
-    - _CrackPosition0: {r: 0, g: 0, b: 0, a: 0}
-    - _CrackPosition1: {r: 0, g: 0, b: 0, a: 0}
-    - _CrackPosition2: {r: 0, g: 0, b: 0, a: 0}
-    - _CritPosition: {r: 0, g: 0, b: 0, a: 0}
+    - _Albedo: {r: 0.28235298, g: 0.8666667, b: 0.8235294, a: 1}
+    - _Color: {r: 0.28248486, g: 0.8679245, b: 0.8249564, a: 1}
+    - _Color0: {r: 0.28235298, g: 0.8666667, b: 0.8235294, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _Vector1: {r: 0, g: 0, b: 0, a: 0}
-    - _VignetteAlignment: {r: 0, g: 1, b: 0, a: 0}
   m_BuildTextureStacks: []

--- a/Assets/Entities/Ore/Mat_OreCrystalNew.mat.meta
+++ b/Assets/Entities/Ore/Mat_OreCrystalNew.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7d9bed9c2c4a0ae4082ebe1ba61b5292
+guid: 3d8c2f9fe13c31440a093e5f6113e164
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Entities/Ore/Ore.prefab
+++ b/Assets/Entities/Ore/Ore.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 155286592657090592}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.438, z: 0.002}
+  m_LocalPosition: {x: 0, y: 0.192, z: 0.002}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7225383730169331487}
@@ -166,7 +166,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 556568147767498150}
-  m_Layer: 20
+  m_Layer: 6
   m_Name: New Mesh
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1439,7 +1439,7 @@ MonoBehaviour:
         PlayEvents:
           m_PersistentCalls:
             m_Calls:
-            - m_Target: {fileID: 3454127850101988312}
+            - m_Target: {fileID: 2722295034177052522}
               m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
               m_MethodName: SetActive
               m_Mode: 6
@@ -2086,7 +2086,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
       propertyPath: m_Layer
-      value: 20
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
@@ -4233,7 +4233,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
       propertyPath: m_Layer
-      value: 20
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
@@ -4279,7 +4279,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   version: 1
-  uniqueID: 9031898642709183510
+  uniqueID: 7768264846170625789
   updateError: 1
   checkTime: 0.2
 --- !u!114 &1281332912521561773
@@ -4370,6 +4370,18 @@ MonoBehaviour:
       - m_Target: {fileID: 5432566915175241370}
         m_TargetAssemblyTypeName: BML.Scripts.Damageable, BML.Scripts
         m_MethodName: TakeDamage
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1281332912521561773}
+        m_TargetAssemblyTypeName: BML.Scripts.OreShaderController, BML.Scripts
+        m_MethodName: UpdateShaderOnPickaxeInteract
         m_Mode: 0
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -4495,18 +4507,6 @@ MonoBehaviour:
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 1281332912521561773}
-        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
-        m_MethodName: 
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: 
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 

--- a/Assets/Entities/Ore/Ore.prefab
+++ b/Assets/Entities/Ore/Ore.prefab
@@ -941,7 +941,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _health: {fileID: 7664960571339365045}
   _critMarkerTransform: {fileID: 0}
-  _renderer: {fileID: 3454127850101988317}
+  _oreRenderer: {fileID: 3454127850101988317}
+  _oreCrystalsRenderer: {fileID: 0}
 --- !u!1 &3454127850225854728
 GameObject:
   m_ObjectHideFlags: 0
@@ -2090,6 +2091,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+--- !u!23 &1925859997282217147 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+  m_PrefabInstance: {fileID: 971531597071691839}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &788459420743620564 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
@@ -4296,7 +4302,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _health: {fileID: 7664960571339365045}
   _critMarkerTransform: {fileID: 517902721090737292}
-  _renderer: {fileID: 7184147944372074786}
+  _oreRenderer: {fileID: 7184147944372074786}
+  _oreCrystalsRenderer: {fileID: 1925859997282217147}
 --- !u!114 &7822768784222172586
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4521,19 +4528,31 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 978657270361522038, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
       propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 978657270361522038, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
       propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 6985341303465785546}
     - target: {fileID: 978657270361522038, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1281332912521561773}
+    - target: {fileID: 978657270361522038, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
       propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: TakeDamage
       objectReference: {fileID: 0}
     - target: {fileID: 978657270361522038, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: UpdateShaderOnPickaxeInteract
+      objectReference: {fileID: 0}
+    - target: {fileID: 978657270361522038, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
       propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: BML.Scripts.Damageables, BML.Scripts
+      objectReference: {fileID: 0}
+    - target: {fileID: 978657270361522038, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
+      propertyPath: _onPickaxeInteract.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: BML.Scripts.OreShaderController, BML.Scripts
       objectReference: {fileID: 0}
     - target: {fileID: 1468530653753540892, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
       propertyPath: health

--- a/Assets/Entities/Ore/Ore.prefab
+++ b/Assets/Entities/Ore/Ore.prefab
@@ -24,11 +24,170 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 155286592657090592}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.503, z: 0.102}
+  m_LocalPosition: {x: 0, y: 0.438, z: 0.002}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 7225383730169331487}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &392644399006347114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8980370900830688701}
+  m_Layer: 0
+  m_Name: Mesh Adjustment
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &8980370900830688701
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392644399006347114}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.75, z: 0}
+  m_LocalScale: {x: 1.5, y: 1.5, z: 1.5}
+  m_Children:
+  - {fileID: 3454127850101988319}
+  m_Father: {fileID: 7225383730169331487}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2348309291656929092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8144536734678889990}
+  - component: {fileID: 2653137566604141230}
+  - component: {fileID: 2110114804312059925}
+  - component: {fileID: 4080254109465773713}
+  m_Layer: 0
+  m_Name: Debug Cylinder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &8144536734678889990
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2348309291656929092}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 1, z: 0.1}
+  m_Children: []
+  m_Father: {fileID: 7225383730169331487}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2653137566604141230
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2348309291656929092}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2110114804312059925
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2348309291656929092}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &4080254109465773713
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2348309291656929092}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!1 &2722295034177052522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 556568147767498150}
+  m_Layer: 20
+  m_Name: New Mesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &556568147767498150
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2722295034177052522}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.2, z: 0}
+  m_LocalScale: {x: 0.7, y: 0.7, z: 0.7}
+  m_Children:
+  - {fileID: 8356451791687746125}
+  - {fileID: 788459420743620564}
+  m_Father: {fileID: 7225383730169331487}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3454127850065686864
 GameObject:
@@ -476,7 +635,7 @@ GameObject:
   - component: {fileID: 7379165262754171365}
   - component: {fileID: 5432566915175241370}
   - component: {fileID: 7827121408468600463}
-  m_Layer: 6
+  m_Layer: 20
   m_Name: Mesh
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -492,11 +651,11 @@ Transform:
   m_GameObject: {fileID: 3454127850101988312}
   m_LocalRotation: {x: -0.054836206, y: 0.7519415, z: 0.6569127, w: -0.0065411245}
   m_LocalPosition: {x: 0.06605148, y: 0.009021997, z: -0.13399887}
-  m_LocalScale: {x: 0.2437, y: 0.2625, z: 0.1787}
+  m_LocalScale: {x: 0.2437, y: 0.2625, z: 0.17870001}
   m_Children:
   - {fileID: 7879620644554891681}
-  m_Father: {fileID: 7225383730169331487}
-  m_RootOrder: 1
+  m_Father: {fileID: 8980370900830688701}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -80.824, y: -149.106, z: -394.82098}
 --- !u!33 &3454127850101988316
 MeshFilter:
@@ -638,13 +797,13 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3454127850101988312}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 183748dd497aa473a98ff0cd8cb67fc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   version: 1
-  uniqueID: 2185014263573092322
+  uniqueID: 5056202087018888271
   updateError: 1
   checkTime: 0.2
 --- !u!114 &5432566915175241370
@@ -781,6 +940,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _health: {fileID: 7664960571339365045}
+  _critMarkerTransform: {fileID: 0}
   _renderer: {fileID: 3454127850101988317}
 --- !u!1 &3454127850225854728
 GameObject:
@@ -813,7 +973,7 @@ Transform:
   - {fileID: 3454127851599513212}
   - {fileID: 4863330317859405944}
   m_Father: {fileID: 7225383730169331487}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3454127851599513213
 GameObject:
@@ -1076,7 +1236,7 @@ MonoBehaviour:
     00000001:
       type: {class: BMLSoundManagerSound, ns: BML.Scripts.MMFFeedbacks, asm: BML.Scripts}
       data:
-        Active: 1
+        Active: 0
         UniqueID: -490137037
         Label: BMLSoundManager Sound
         ChannelMode: 0
@@ -1303,6 +1463,18 @@ MonoBehaviour:
                 m_StringArgument: 
                 m_BoolArgument: 0
               m_CallState: 2
+            - m_Target: {fileID: 2722295034177052522}
+              m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
+              m_MethodName: SetActive
+              m_Mode: 6
+              m_Arguments:
+                m_ObjectArgument: {fileID: 0}
+                m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+                m_IntArgument: 0
+                m_FloatArgument: 0
+                m_StringArgument: 
+                m_BoolArgument: 0
+              m_CallState: 2
         StopEvents:
           m_PersistentCalls:
             m_Calls: []
@@ -1473,7 +1645,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7879620644554891681}
-  m_Layer: 6
+  m_Layer: 20
   m_Name: OreCrystals
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1534,7 +1706,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4472804554480619527}
-  - {fileID: 3454127850101988319}
+  - {fileID: 8144536734678889990}
+  - {fileID: 556568147767498150}
+  - {fileID: 8980370900830688701}
   - {fileID: 3454127850225854731}
   - {fileID: 517902721090737292}
   m_Father: {fileID: 0}
@@ -1552,7 +1726,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1e04cd80442130c41a74a36c671de6e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _oreCollider: {fileID: 182695390771352254}
+  _oreCollider: {fileID: 771399382741072669}
   _health: {fileID: 7664960571339365045}
   _critMarker: {fileID: 2238584893062115824}
   _critMarkerMinMaxAngle: {x: 15, y: 36.391033}
@@ -1851,6 +2025,76 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 589333140407981596, guid: 10ef57ca79f39aa4fb53200ff459ad4b, type: 3}
   m_PrefabInstance: {fileID: 849565726790984777}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &971531597071691839
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 556568147767498150}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 3d8c2f9fe13c31440a093e5f6113e164, type: 2}
+    - target: {fileID: 919132149155446097, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_Name
+      value: Ore_Common
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+      propertyPath: m_Layer
+      value: 20
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+--- !u!4 &788459420743620564 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: d3cffb52b3f502e4abad73bffa3bd25c, type: 3}
+  m_PrefabInstance: {fileID: 971531597071691839}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1974869472496974161
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1927,14 +2171,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6da43522623d4704e979466dc7650b65, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &6186111361755649282 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5670417655354747987, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
-  m_PrefabInstance: {fileID: 1974869472496974161}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &4863330317859405944 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6347296434736609577, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
+  m_PrefabInstance: {fileID: 1974869472496974161}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6186111361755649282 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5670417655354747987, guid: 236b0b3714b76b24a91f153efb345cc8, type: 3}
   m_PrefabInstance: {fileID: 1974869472496974161}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &4895746909303588898
@@ -3924,6 +4168,350 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 589333140407981596, guid: 10ef57ca79f39aa4fb53200ff459ad4b, type: 3}
   m_PrefabInstance: {fileID: 8000421381884599838}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8390960216895972774
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 556568147767498150}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: a5f0f062f3b77894ebb415a638bffa42, type: 2}
+    - target: {fileID: 919132149155446097, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_Name
+      value: Ore_Base.001
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+      propertyPath: m_Layer
+      value: 20
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+--- !u!23 &7184147944372074786 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+  m_PrefabInstance: {fileID: 8390960216895972774}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8356451791687746125 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+  m_PrefabInstance: {fileID: 8390960216895972774}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8697510868860655863 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+  m_PrefabInstance: {fileID: 8390960216895972774}
+  m_PrefabAsset: {fileID: 0}
+--- !u!64 &771399382741072669
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8697510868860655863}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: -8000335543822411570, guid: ec897aacfbf6677438a7b01f0c69c16d, type: 3}
+--- !u!114 &937728623026763691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8697510868860655863}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 183748dd497aa473a98ff0cd8cb67fc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 1
+  uniqueID: 9031898642709183510
+  updateError: 1
+  checkTime: 0.2
+--- !u!114 &1281332912521561773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8697510868860655863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45fc6fa940a34d65adfcefad774e38d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _health: {fileID: 7664960571339365045}
+  _critMarkerTransform: {fileID: 517902721090737292}
+  _renderer: {fileID: 7184147944372074786}
+--- !u!114 &7822768784222172586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8697510868860655863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96e5457f6d8871d4a9d6dc9518bc622e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 11400000, guid: 1d18a3528e56519478ac9fb768afcc25, type: 2}
+        m_TargetAssemblyTypeName: BML.ScriptableObjectCore.Scripts.Events.GameEvent,
+          ScriptableObjectSystem
+        m_MethodName: Raise
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  _onPickaxeInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5432566915175241370}
+        m_TargetAssemblyTypeName: BML.Scripts.Damageable, BML.Scripts
+        m_MethodName: TakeDamage
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 2450872905461499138}
+        m_TargetAssemblyTypeName: BML.Scripts.OreCritMarker, BML.Scripts
+        m_MethodName: ActivateCritMarker
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1281332912521561773}
+        m_TargetAssemblyTypeName: BML.Scripts.OreShaderController, BML.Scripts
+        m_MethodName: UpdateShaderOnPickaxeInteract
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  _onPickaxeSecondaryInteract:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5432566915175241370}
+        m_TargetAssemblyTypeName: BML.Scripts.Damageable, BML.Scripts
+        m_MethodName: TakeDamage
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &8336719830337771614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8697510868860655863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2fe64b9028caa84a8a9952a1342dbbd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: {fileID: 7664960571339365045}
+  _damageable:
+  - _damageTypesPreview: Player_Pickaxe, Player_Bomb, Enemy_Sentinel_Projectile,
+      Enemy_Mimic_Projectile, Ore_Explosive, Enemy_Snake_Projectile, Player_Pickaxe_Secondary,
+      Enemy_Bomb_Explosion, Trap_Stalactite, Enemy_Worm
+    _damageType: 28115
+    _damageModifierType: 0
+    _damageMultiplier:
+      ReferenceTypeSelector: 0
+      ConstantValue: 1
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageResistance:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageOverride:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _onDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onFailDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onDeath:
+      m_PersistentCalls:
+        m_Calls: []
+  - _damageTypesPreview: Trap_Spike
+    _damageType: 4096
+    _damageModifierType: 2
+    _damageMultiplier:
+      ReferenceTypeSelector: 0
+      ConstantValue: 1
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageResistance:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _damageOverride:
+      ReferenceTypeSelector: 0
+      ConstantValue: 0
+      RoundingBehavior: 0
+      ReferenceValue_FloatVariable: {fileID: 0}
+      ReferenceValue_IntVariable: {fileID: 0}
+      ReferenceValue_BoolVariable: {fileID: 0}
+      ReferenceValue_FunctionVariable: {fileID: 0}
+      ReferenceValue_EvaluateCurveVariable: {fileID: 0}
+    _onDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onFailDamage:
+      m_PersistentCalls:
+        m_Calls: []
+    _onDeath:
+      m_PersistentCalls:
+        m_Calls: []
+  _onDamage:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7098438743458149331}
+        m_TargetAssemblyTypeName: BML.Scripts.MoveToHitPositon, BML.Scripts
+        m_MethodName: Move
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 3454127850065686866}
+        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+        m_MethodName: PlayFeedbacks
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1281332912521561773}
+        m_TargetAssemblyTypeName: MoreMountains.Feedbacks.MMF_Player, MoreMountains.Feedbacks
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1001 &8399686363568519638
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4053,7 +4641,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8340204686617603418, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8340204686617603418, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4097,6 +4685,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
+--- !u!1 &2238584893062115824 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7746370747038451750, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
+  m_PrefabInstance: {fileID: 8399686363568519638}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &517902721090737292 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8340204686617603418, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
@@ -4113,8 +4706,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e2fe64b9028caa84a8a9952a1342dbbd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &2238584893062115824 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7746370747038451750, guid: 1294a8d6407f78d488da1ae2bedf1f29, type: 3}
-  m_PrefabInstance: {fileID: 8399686363568519638}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Entities/Ore/Ore_Barrier.001.fbx
+++ b/Assets/Entities/Ore/Ore_Barrier.001.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33181d431c204fae1a30832b0d8a83e061c91532967f0ff9149fbcdb0ba0739e
-size 19468
+oid sha256:f92a441dbd7d8c0b39e8dd1a0bce4e8af09b8595985bc56e078cbe3ab9555710
+size 19612

--- a/Assets/Entities/Ore/Ore_Barrier.001.fbx
+++ b/Assets/Entities/Ore/Ore_Barrier.001.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33181d431c204fae1a30832b0d8a83e061c91532967f0ff9149fbcdb0ba0739e
+size 19468

--- a/Assets/Entities/Ore/Ore_Barrier.001.fbx.meta
+++ b/Assets/Entities/Ore/Ore_Barrier.001.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: b735b187c3daa21469dd9edb1342f1c4
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/Ore_Base.001.fbx
+++ b/Assets/Entities/Ore/Ore_Base.001.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15391420fdac143f734365e298aff484e2b46109d198ec7764f928668c68daff
-size 17836
+oid sha256:ecefe411354dbf98b0bc2eee651ade7b44bf0132c28bf6857dfa22171fdccc29
+size 18492

--- a/Assets/Entities/Ore/Ore_Base.001.fbx
+++ b/Assets/Entities/Ore/Ore_Base.001.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15391420fdac143f734365e298aff484e2b46109d198ec7764f928668c68daff
+size 17836

--- a/Assets/Entities/Ore/Ore_Base.001.fbx.meta
+++ b/Assets/Entities/Ore/Ore_Base.001.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: ec897aacfbf6677438a7b01f0c69c16d
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/Ore_Base.002.fbx
+++ b/Assets/Entities/Ore/Ore_Base.002.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e12f13446a12ea28a478631fd03f496561bc49eb89d7b15c96b56c84cbdd6d2e
+size 14492

--- a/Assets/Entities/Ore/Ore_Base.002.fbx
+++ b/Assets/Entities/Ore/Ore_Base.002.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e12f13446a12ea28a478631fd03f496561bc49eb89d7b15c96b56c84cbdd6d2e
-size 14492
+oid sha256:9e736859a74ae05df166cfe0f64ac4fef2be53efdcb3b40d1587497c3ae75a16
+size 18492

--- a/Assets/Entities/Ore/Ore_Base.002.fbx.meta
+++ b/Assets/Entities/Ore/Ore_Base.002.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: 6e9de6aeaa9c0464d8df44a2f8e44709
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/Ore_Common.fbx
+++ b/Assets/Entities/Ore/Ore_Common.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cffc346bf7a7f0abc9c1a347d337371c0c253f737d0b1bb79baf2d810b2aafa2
+size 14300

--- a/Assets/Entities/Ore/Ore_Common.fbx.meta
+++ b/Assets/Entities/Ore/Ore_Common.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: d3cffb52b3f502e4abad73bffa3bd25c
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/Ore_Rare.fbx
+++ b/Assets/Entities/Ore/Ore_Rare.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb73d1c8991cc6f34a49af77bf555db96f9e9ce4537495e2f2028d1f67bc9c4f
+size 14556

--- a/Assets/Entities/Ore/Ore_Rare.fbx.meta
+++ b/Assets/Entities/Ore/Ore_Rare.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: 07f6979e2475cf747b8bbf71459cbc6f
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/RareOre/Ore_Rare.prefab
+++ b/Assets/Entities/Ore/RareOre/Ore_Rare.prefab
@@ -89,6 +89,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 124687947047603566, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 281467110861517397, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.8761
@@ -215,7 +219,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: f60021c27b6eb0647b942405d60b9678, type: 2}
     - target: {fileID: 517902721090737292, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 530843240281542563, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -605,6 +609,10 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: 8ffa8b22a6f5be948907244d15314835, type: 2}
+    - target: {fileID: 3454127850225854731, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: FeedbacksList.Array.data[1].PlayEvents.m_PersistentCalls.m_Calls.Array.size
       value: 3
@@ -1837,6 +1845,10 @@ PrefabInstance:
       propertyPath: m_Mesh
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 8980370900830688701, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 9106268291920902855, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Enabled
       value: 1
@@ -1852,6 +1864,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7225383730169331487, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 6078468993030459640}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &6044495423550522718 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 6078468993030459640}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7465009430006410467 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3729549894264273947, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
@@ -1863,3 +1880,64 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2f680a7afde40b49d9741bdbc7aa5bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &8301770311052609509
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6044495423550522718}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.00000023841858
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.49999994
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.50000006
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.49999997
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f60021c27b6eb0647b942405d60b9678, type: 2}
+    - target: {fileID: 919132149155446097, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
+      propertyPath: m_Name
+      value: Ore_Rare
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}

--- a/Assets/Entities/Ore/RareOre/Ore_Rare.prefab
+++ b/Assets/Entities/Ore/RareOre/Ore_Rare.prefab
@@ -91,7 +91,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 124687947047603566, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 281467110861517397, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_LocalScale.x
@@ -289,6 +289,10 @@ PrefabInstance:
       propertyPath: m_Tangents.Array.data[14].z
       value: -0.7076672
       objectReference: {fileID: 0}
+    - target: {fileID: 937728623026763691, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: uniqueID
+      value: 4457235139151942893
+      objectReference: {fileID: 0}
     - target: {fileID: 1170534869451340434, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
       value: 
@@ -438,6 +442,10 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1914735309729022096, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: f60021c27b6eb0647b942405d60b9678, type: 2}
+    - target: {fileID: 1925859997282217147, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: f60021c27b6eb0647b942405d60b9678, type: 2}
@@ -789,6 +797,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -245.856
       objectReference: {fileID: 0}
+    - target: {fileID: 4422236038222895217, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: -4025189435436147644, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
     - target: {fileID: 4459669273883504506, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Materials.Array.data[0]
       value: 
@@ -1881,11 +1893,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 2722295034177052522, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 6078468993030459640}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &6044495423550522718 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
-  m_PrefabInstance: {fileID: 6078468993030459640}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7465009430006410467 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3729549894264273947, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
@@ -1897,64 +1904,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2f680a7afde40b49d9741bdbc7aa5bd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &8301770311052609509
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 6044495423550522718}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -7511558181221131132, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: f60021c27b6eb0647b942405d60b9678, type: 2}
-    - target: {fileID: 919132149155446097, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
-      propertyPath: m_Name
-      value: Ore_Rare
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}

--- a/Assets/Entities/Ore/RareOre/Ore_Rare.prefab
+++ b/Assets/Entities/Ore/RareOre/Ore_Rare.prefab
@@ -219,7 +219,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: f60021c27b6eb0647b942405d60b9678, type: 2}
     - target: {fileID: 517902721090737292, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 530843240281542563, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Mesh
@@ -553,6 +553,10 @@ PrefabInstance:
       propertyPath: _onDeath.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
+    - target: {fileID: 2722295034177052522, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3062608059608078923, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_Enabled
       value: 0
@@ -611,7 +615,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 8ffa8b22a6f5be948907244d15314835, type: 2}
     - target: {fileID: 3454127850225854731, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: FeedbacksList.Array.data[1].PlayEvents.m_PersistentCalls.m_Calls.Array.size
@@ -634,6 +638,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1373270573095262472}
     - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: FeedbacksList.Array.data[2].PlayEvents.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 8186567417302896530}
+    - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: FeedbacksList.Array.data[2].PlayEvents.m_PersistentCalls.m_Calls.Array.data[2].m_Target
       value: 
       objectReference: {fileID: 1373270573095262472}
@@ -647,6 +655,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
       propertyPath: FeedbacksList.Array.data[1].PlayEvents.m_PersistentCalls.m_Calls.Array.data[2].m_MethodName
+      value: SetActive
+      objectReference: {fileID: 0}
+    - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+      propertyPath: FeedbacksList.Array.data[2].PlayEvents.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: SetActive
       objectReference: {fileID: 0}
     - target: {fileID: 3454127851599513215, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
@@ -1864,6 +1876,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7225383730169331487, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
   m_PrefabInstance: {fileID: 6078468993030459640}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8186567417302896530 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2722295034177052522, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
+  m_PrefabInstance: {fileID: 6078468993030459640}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6044495423550522718 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 556568147767498150, guid: ecf6c3d1754d244429e5217073d71ff5, type: 3}
@@ -1901,23 +1918,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.00000023841858
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.49999994
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.50000006
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.50000006
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.49999997
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 07f6979e2475cf747b8bbf71459cbc6f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/Assets/Entities/Ore/RareOre/Rare_OreCrystal.mat.meta
+++ b/Assets/Entities/Ore/RareOre/Rare_OreCrystal.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f60021c27b6eb0647b942405d60b9678
+guid: 57919bc5249cc54439ac206a68d9d4ab
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Entities/Ore/RareOre/Rare_OreCrystalNew.mat
+++ b/Assets/Entities/Ore/RareOre/Rare_OreCrystalNew.mat
@@ -7,10 +7,10 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Ore_CommonNew
-  m_Shader: {fileID: 4800000, guid: 835721fa6edc42543a9793e37ba98b5a, type: 3}
+  m_Name: Rare_OreCrystalNew
+  m_Shader: {fileID: 4800000, guid: 1df71dc43c1ae464a80657ff347370b0, type: 3}
   m_ShaderKeywords: 
-  m_LightmapFlags: 0
+  m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
@@ -55,24 +55,24 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _texcoord:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     m_Floats:
     - _BumpScale: 1
     - _Cutoff: 0.5
+    - _DamageFac: 0
+    - _DamageInsetMultiplier: -0.198
+    - _DamageMax: 0
+    - _DamageScaleMultiplier: -0.16
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
-    - _EdgeLength: 15
-    - _Float2: -0.3
+    - _Float0: -0.25
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
-    - _Metallic: 0
+    - _Metallic: 0.5
     - _Mode: 0
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _SmoothnessMetallic: 0.383
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
@@ -80,15 +80,8 @@ Material:
     - _ZWrite: 1
     - __dirty: 0
     m_Colors:
-    - _Albedo: {r: 0.5372549, g: 0.4632539, b: 0.3825255, a: 1}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _CrackAlbedo: {r: 0.36078432, g: 0.3237438, b: 0.28141177, a: 1}
-    - _CrackLightness: {r: 0.7924528, g: 0.7924528, b: 0.7924528, a: 1}
-    - _CrackPosition0: {r: 0, g: 0, b: 0, a: 0}
-    - _CrackPosition1: {r: 0, g: 0, b: 0, a: 0}
-    - _CrackPosition2: {r: 0, g: 0, b: 0, a: 0}
-    - _CritPosition: {r: 0, g: 0, b: 0, a: 0}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _Vector1: {r: 0, g: 0, b: 0, a: 0}
-    - _VignetteAlignment: {r: 0, g: 1, b: 0, a: 0}
+    - _Albedo: {r: 0.93333334, g: 0.6901961, b: 0.20784286, a: 1}
+    - _Color: {r: 0.9339623, g: 0.6900345, b: 0.20705767, a: 1}
+    - _Color0: {r: 0.28235298, g: 0.8666667, b: 0.8235294, a: 1}
+    - _EmissionColor: {r: 0.6981132, g: 0.24038802, b: 0.69768673, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Entities/Ore/RareOre/Rare_OreCrystalNew.mat.meta
+++ b/Assets/Entities/Ore/RareOre/Rare_OreCrystalNew.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7d9bed9c2c4a0ae4082ebe1ba61b5292
+guid: f60021c27b6eb0647b942405d60b9678
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Entities/Ore/Shader_Ore.shader
+++ b/Assets/Entities/Ore/Shader_Ore.shader
@@ -171,7 +171,8 @@ return F1;
 			float clampResult26 = clamp( ( 0.5 * distance( float3(0,0,0) , modifiedUV100 ) ) , 0.0 , 1.0 );
 			float distanceMask112 = ( 1.0 - clampResult26 );
 			float3 ase_worldNormal = UnityObjectToWorldNormal( v.normal );
-			float smoothstepResult82 = smoothstep( -0.001 , 0.0 , ase_worldNormal.y);
+			float3 worldToObjDir151 = mul( unity_WorldToObject, float4( ase_worldNormal, 0 ) ).xyz;
+			float smoothstepResult82 = smoothstep( -0.001 , 0.0 , worldToObjDir151.y);
 			float topMask143 = smoothstepResult82;
 			float combinedMask144 = ( distanceMask112 * topMask143 );
 			float _VertexCrackStrengthFactor_Instance = UNITY_ACCESS_INSTANCED_PROP(_VertexCrackStrengthFactor_arr, _VertexCrackStrengthFactor);
@@ -209,7 +210,8 @@ return F1;
 			float4 blendOpDest77 = ( saturate( ( blendOpSrc37 * blendOpDest37 ) ));
 			float _CrackStrengthFactor_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackStrengthFactor_arr, _CrackStrengthFactor);
 			float3 ase_worldNormal = i.worldNormal;
-			float smoothstepResult82 = smoothstep( -0.001 , 0.0 , ase_worldNormal.y);
+			float3 worldToObjDir151 = mul( unity_WorldToObject, float4( ase_worldNormal, 0 ) ).xyz;
+			float smoothstepResult82 = smoothstep( -0.001 , 0.0 , worldToObjDir151.y);
 			float topMask143 = smoothstepResult82;
 			float combinedMask144 = ( distanceMask112 * topMask143 );
 			float time95 = 0.0;
@@ -303,12 +305,12 @@ return F1;
 }
 /*ASEBEGIN
 Version=18935
-0;0;1097.143;664.7143;-769.6565;202.2378;1;True;False
+1102;244;1693;1016;1669.206;-107.0812;1;True;True
 Node;AmplifyShaderEditor.DynamicAppendNode;118;-2080,-352;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.TransformDirectionNode;117;-1952,-352;Inherit;False;World;Object;False;Fast;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.PosVertexDataNode;5;-1920,-512;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.TransformDirectionNode;117;-1952,-352;Inherit;False;World;Object;False;Fast;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.FunctionNode;120;-1728,-448;Inherit;False;Projection;-1;;1;3249e2c8638c9ef4bbd1902a2d38a67c;0;2;5;FLOAT3;0,0,0;False;6;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.Vector3Node;127;-1568,-352;Inherit;False;InstancedProperty;_CenterOffset;Center Offset;12;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;127;-1568,-352;Inherit;False;InstancedProperty;_CenterOffset;Center Offset;12;0;Create;True;0;0;0;False;0;False;0,0,0;-0.26,-0.81,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.SimpleSubtractOpNode;125;-1568,-512;Inherit;False;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.SimpleAddOpNode;126;-1408,-512;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.RegisterLocalVarNode;100;-1280,-512;Inherit;False;modifiedUV;-1;True;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
@@ -316,58 +318,60 @@ Node;AmplifyShaderEditor.Vector3Node;111;-1462.086,302.2205;Inherit;False;Consta
 Node;AmplifyShaderEditor.GetLocalVarNode;102;-1457.103,503.9467;Inherit;False;100;modifiedUV;1;0;OBJECT;;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.RangedFloatNode;25;-1220.134,392.2138;Inherit;False;Constant;_Float0;Float 0;2;0;Create;True;0;0;0;False;0;False;0.5;0.5;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.DistanceOpNode;22;-1220.134,488.2137;Inherit;False;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;24;-1060.134,392.2138;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.WorldNormalVector;96;-1024,768;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.ClampOpNode;26;-836.1335,392.2138;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TransformDirectionNode;151;-1007.614,920.071;Inherit;False;World;Object;False;Fast;False;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;24;-1060.134,392.2138;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.BreakToComponentsNode;80;-832,768;Inherit;False;FLOAT3;1;0;FLOAT3;0,0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.ClampOpNode;26;-836.1335,392.2138;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SmoothstepOpNode;82;-704,768;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;-0.001;False;2;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.OneMinusNode;23;-612.1335,392.2138;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.RegisterLocalVarNode;112;-384,448;Inherit;False;distanceMask;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.RegisterLocalVarNode;143;-384,832;Inherit;False;topMask;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;40;-1272,156;Inherit;False;Property;_VertexCrackScale;Vertex Crack Scale;3;0;Create;True;0;0;0;False;0;False;0.56;0.5;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.GetLocalVarNode;101;-1262.358,0.6077805;Inherit;False;100;modifiedUV;1;0;OBJECT;;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;142;-128,704;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RegisterLocalVarNode;144;32,704;Inherit;False;combinedMask;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;99;-992,-608;Inherit;False;Property;_CrackScale;Crack Scale;4;0;Create;True;0;0;0;False;0;False;2;0.5;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;108;-1040.265,-830.0291;Inherit;False;Property;_MinCrackStrength;Min Crack Strength;11;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;107;-1040.265,-734.0291;Inherit;False;Property;_MaxCrackStrength;Max Crack Strength;9;0;Create;True;0;0;0;False;0;False;6;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;35;-1072,-96;Inherit;False;Property;_VertexCrackThickness;Vertex Crack Thickness;2;0;Create;True;0;0;0;False;0;False;0.37;0.06;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;40;-1272,156;Inherit;False;Property;_VertexCrackScale;Vertex Crack Scale;3;0;Create;True;0;0;0;False;0;False;0.56;0.36;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;101;-1262.358,0.6077805;Inherit;False;100;modifiedUV;1;0;OBJECT;;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.VoronoiNode;1;-1024,0;Inherit;True;0;0;1;2;1;False;1;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;0.95;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
+Node;AmplifyShaderEditor.RangedFloatNode;35;-1072,-96;Inherit;False;Property;_VertexCrackThickness;Vertex Crack Thickness;2;0;Create;True;0;0;0;False;0;False;0.37;0.26;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;108;-1040.265,-830.0291;Inherit;False;Property;_MinCrackStrength;Min Crack Strength;11;0;Create;True;0;0;0;False;0;False;0;0.5;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;99;-992,-608;Inherit;False;Property;_CrackScale;Crack Scale;4;0;Create;True;0;0;0;False;0;False;2;1.7;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;107;-1040.265,-734.0291;Inherit;False;Property;_MaxCrackStrength;Max Crack Strength;9;0;Create;True;0;0;0;False;0;False;6;2.5;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.RangedFloatNode;106;-1040.265,-926.029;Inherit;False;InstancedProperty;_CrackStrengthFactor;Crack Strength Factor;7;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;43;-864,224;Inherit;False;Property;_DebugVertexCrack;Debug Vertex Crack;5;0;Create;True;0;0;0;False;0;False;0;0.75;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.OneMinusNode;36;-832,-96;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.GetLocalVarNode;114;-733,-722;Inherit;False;144;combinedMask;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RegisterLocalVarNode;144;32,704;Inherit;False;combinedMask;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.OneMinusNode;28;-848,0;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;43;-864,224;Inherit;False;Property;_DebugVertexCrack;Debug Vertex Crack;5;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;109;-752.2649,-926.029;Inherit;False;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;114;-733,-722;Inherit;False;144;combinedMask;1;0;OBJECT;;False;1;FLOAT;0
+Node;AmplifyShaderEditor.OneMinusNode;36;-832,-96;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.VoronoiNode;95;-768,-608;Inherit;True;0;0;1;4;1;False;1;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;2;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;110;-515,-845;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.OneMinusNode;44;-576,224;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;147;-505.8819,-638.444;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.FunctionNode;34;-672,-96;Inherit;True;Step Antialiasing;-1;;138;2a825e80dfb3290468194f83380797bd;0;2;1;FLOAT;0.94;False;2;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.StepOpNode;42;-240,160;Inherit;True;2;0;FLOAT;0.74;False;1;FLOAT;0.81;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RegisterLocalVarNode;97;-433.0083,-99.74791;Inherit;False;vertexCracks;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;138;-669.6787,-337.3978;Inherit;False;Property;_Float1;Float 1;13;0;Create;True;0;0;0;False;0;False;0;0.2;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.SimpleSubtractOpNode;93;-273.8158,-721.7497;Inherit;False;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;139;-650.6787,-250.3978;Inherit;False;Property;_Float2;Float 2;14;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;138;-669.6787,-337.3978;Inherit;False;Property;_Float1;Float 1;13;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.BlendOpsNode;21;-133.6875,-206.4275;Inherit;True;Multiply;True;3;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;140;-233.6787,-308.3978;Inherit;False;Property;_Float3;Float 3;15;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;137;-466.0967,-444.6071;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.21;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;139;-650.6787,-250.3978;Inherit;False;Property;_Float2;Float 2;14;0;Create;True;0;0;0;False;0;False;0;-1.86;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RegisterLocalVarNode;97;-433.0083,-99.74791;Inherit;False;vertexCracks;-1;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.StepOpNode;42;-240,160;Inherit;True;2;0;FLOAT;0.74;False;1;FLOAT;0.81;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;135;-134.4581,-791.6185;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;2;376.5393,-812.9259;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.4039216,0.2980392,0.07843138,1;0.4039216,0.2980392,0.07843138,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SmoothstepOpNode;137;-466.0967,-444.6071;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.21;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;21;-133.6875,-206.4275;Inherit;True;Multiply;True;3;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;140;-233.6787,-308.3978;Inherit;False;Property;_Float3;Float 3;15;0;Create;True;0;0;0;False;0;False;0;-9.53;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;2;376.5393,-812.9259;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.4039216,0.2980392,0.07843138,1;0.3679245,0.3679245,0.3679245,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.OneMinusNode;38;376.5393,-620.9261;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;70;432,368;Inherit;False;InstancedProperty;_VertexCrackStrengthFactor;Vertex Crack Strength Factor;6;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;105;432,464;Inherit;False;Property;_MinVertexCrackStrength;Min Vertex Crack Strength;10;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;-77.67871,-443.3978;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;104;432,560;Inherit;False;Property;_MaxVertexCrackStrength;Max Vertex Crack Strength;8;0;Create;True;0;0;0;False;0;False;-3;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.RoundOpNode;90;-67,-598;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;104;432,560;Inherit;False;Property;_MaxVertexCrackStrength;Max Vertex Crack Strength;8;0;Create;True;0;0;0;False;0;False;-3;-1;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;-77.67871,-443.3978;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;105;432,464;Inherit;False;Property;_MinVertexCrackStrength;Min Vertex Crack Strength;10;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;70;432,368;Inherit;False;InstancedProperty;_VertexCrackStrengthFactor;Vertex Crack Strength Factor;6;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.GetLocalVarNode;113;653.9899,256.3004;Inherit;False;144;combinedMask;1;0;OBJECT;;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;103;720,368;Inherit;False;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.BlendOpsNode;37;608,-704;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;1;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.SimpleAddOpNode;136;88.90332,-509.6071;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;76;656,-464;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;0.4039216,0.2980392,0.07843138,1;0.4039216,0.2980392,0.07843138,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ColorNode;76;656,-464;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;0.4039216,0.2980392,0.07843138,1;0.2339999,0.2339999,0.2339999,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.NormalVertexDataNode;67;648.588,75.98205;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.GetLocalVarNode;113;653.9899,256.3004;Inherit;False;144;combinedMask;1;0;OBJECT;;False;1;FLOAT;0
-Node;AmplifyShaderEditor.BlendOpsNode;77;896,-544;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0.2924528,0.2580149,0.2002238,0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;68;1031.668,125.5068;Inherit;True;4;4;0;FLOAT3;0,0,0;False;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.WorldToObjectMatrix;148;-160.0864,962.1072;Inherit;False;0;1;FLOAT4x4;0
+Node;AmplifyShaderEditor.BlendOpsNode;77;896,-544;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0.2924528,0.2580149,0.2002238,0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;1548.377,-250.3481;Float;False;True;-1;2;ASEMaterialInspector;0;0;Standard;Shader_Ore;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;1;False;-1;1;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
 WireConnection;117;0;118;0
 WireConnection;120;5;5;0
@@ -379,24 +383,25 @@ WireConnection;126;1;127;0
 WireConnection;100;0;126;0
 WireConnection;22;0;111;0
 WireConnection;22;1;102;0
+WireConnection;151;0;96;0
 WireConnection;24;0;25;0
 WireConnection;24;1;22;0
+WireConnection;80;0;151;0
 WireConnection;26;0;24;0
-WireConnection;80;0;96;0
 WireConnection;82;0;80;1
 WireConnection;23;0;26;0
 WireConnection;112;0;23;0
 WireConnection;143;0;82;0
 WireConnection;142;0;112;0
 WireConnection;142;1;143;0
-WireConnection;144;0;142;0
 WireConnection;1;0;101;0
 WireConnection;1;2;40;0
-WireConnection;36;0;35;0
+WireConnection;144;0;142;0
 WireConnection;28;0;1;0
 WireConnection;109;0;106;0
 WireConnection;109;3;108;0
 WireConnection;109;4;107;0
+WireConnection;36;0;35;0
 WireConnection;95;0;100;0
 WireConnection;95;2;99;0
 WireConnection;110;0;109;0
@@ -406,21 +411,21 @@ WireConnection;147;0;114;0
 WireConnection;147;1;95;0
 WireConnection;34;1;36;0
 WireConnection;34;2;28;0
-WireConnection;42;0;44;0
-WireConnection;42;1;112;0
-WireConnection;97;0;34;0
 WireConnection;93;0;110;0
 WireConnection;93;1;147;0
-WireConnection;21;0;97;0
-WireConnection;21;1;42;0
+WireConnection;97;0;34;0
+WireConnection;42;0;44;0
+WireConnection;42;1;112;0
+WireConnection;135;0;93;0
 WireConnection;137;0;147;0
 WireConnection;137;1;138;0
 WireConnection;137;2;139;0
-WireConnection;135;0;93;0
+WireConnection;21;0;97;0
+WireConnection;21;1;42;0
 WireConnection;38;0;21;0
+WireConnection;90;0;135;0
 WireConnection;141;0;137;0
 WireConnection;141;1;140;0
-WireConnection;90;0;135;0
 WireConnection;103;0;70;0
 WireConnection;103;3;105;0
 WireConnection;103;4;104;0
@@ -428,14 +433,14 @@ WireConnection;37;0;2;0
 WireConnection;37;1;38;0
 WireConnection;136;0;90;0
 WireConnection;136;1;141;0
-WireConnection;77;0;76;0
-WireConnection;77;1;37;0
-WireConnection;77;2;136;0
 WireConnection;68;0;67;0
 WireConnection;68;1;34;0
 WireConnection;68;2;113;0
 WireConnection;68;3;103;0
+WireConnection;77;0;76;0
+WireConnection;77;1;37;0
+WireConnection;77;2;136;0
 WireConnection;0;0;77;0
 WireConnection;0;11;68;0
 ASEEND*/
-//CHKSM=BEE6BE61F050485AFC2495AE7DD2813C829D7704
+//CHKSM=FA15BF1199C3975CB92342DE0A074B9C86BADC31

--- a/Assets/Entities/Ore/Shader_OreCrystalNew.shader
+++ b/Assets/Entities/Ore/Shader_OreCrystalNew.shader
@@ -7,7 +7,7 @@ Shader "Shader_OreCrystalNew"
 	Properties
 	{
 		_SmoothnessMetallic("Smoothness+Metallic", Range( 0 , 1)) = 0.383
-		_Albedo("Albedo", Color) = (0.282353,0.8666667,0.8235294,1)
+		_Color("Color", Color) = (0.282353,0.8666667,0.8235294,1)
 		_DamageFac("DamageFac", Range( 0 , 1)) = 0
 		_DamageInsetMultiplier("DamageInsetMultiplier", Range( -1 , 1)) = -0.18
 		_DamageScaleMultiplier("DamageScaleMultiplier", Range( -2 , 2)) = -0.05
@@ -29,7 +29,7 @@ Shader "Shader_OreCrystalNew"
 
 		uniform float _DamageInsetMultiplier;
 		uniform float _DamageScaleMultiplier;
-		uniform float4 _Albedo;
+		uniform float4 _Color;
 		uniform float _SmoothnessMetallic;
 
 		UNITY_INSTANCING_BUFFER_START(Shader_OreCrystalNew)
@@ -54,7 +54,7 @@ Shader "Shader_OreCrystalNew"
 
 		void surf( Input i , inout SurfaceOutputStandard o )
 		{
-			o.Albedo = _Albedo.rgb;
+			o.Albedo = _Color.rgb;
 			float temp_output_2_0 = _SmoothnessMetallic;
 			o.Metallic = temp_output_2_0;
 			o.Smoothness = temp_output_2_0;
@@ -68,7 +68,7 @@ Shader "Shader_OreCrystalNew"
 }
 /*ASEBEGIN
 Version=18935
-679;503;1880;1021;1462.574;-839.7872;1;True;True
+869;424;1729;955;805.6033;-531.7943;1;True;True
 Node;AmplifyShaderEditor.CommentaryNode;49;-988.8012,916.2682;Inherit;False;996.7859;503.8422;Use 'Damage Factor' to lerp the highest vertices down;9;17;20;26;47;10;48;12;27;61;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.RangedFloatNode;10;-946.8012,955.2682;Inherit;False;InstancedProperty;_DamageFac;DamageFac;2;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;50;-1057.222,1488.258;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0.7;False;4;FLOAT;0.4;False;1;FLOAT;0
@@ -78,11 +78,11 @@ Node;AmplifyShaderEditor.ClampOpNode;54;-776.2219,1490.258;Inherit;False;3;0;FLO
 Node;AmplifyShaderEditor.DynamicAppendNode;56;-587.6083,1452.767;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.RangedFloatNode;61;-948.6083,1052.767;Inherit;False;Property;_DamageInsetMultiplier;DamageInsetMultiplier;3;0;Create;True;0;0;0;False;0;False;-0.18;0;-1;1;0;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;26;-610.015,1166.11;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.7;False;2;FLOAT;0.73;False;3;FLOAT;0;False;4;FLOAT;0.5;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;47;-339.6006,1165.847;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;60;-610.6083,1619.767;Inherit;False;Property;_DamageScaleMultiplier;DamageScaleMultiplier;4;0;Create;True;0;0;0;False;0;False;-0.05;-0.05;-2;2;0;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalizeNode;57;-451.6083,1452.767;Inherit;False;False;1;0;FLOAT4;0,0,0,0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.DynamicAppendNode;12;-330.858,1007.186;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.TFHCRemapNode;48;-642.6004,968.8472;Inherit;False;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;-0.6;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;60;-610.6083,1619.767;Inherit;False;Property;_DamageScaleMultiplier;DamageScaleMultiplier;4;0;Create;True;0;0;0;False;0;False;-0.05;-0.05;-2;2;0;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;47;-339.6006,1165.847;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.NormalizeNode;57;-451.6083,1452.767;Inherit;False;False;1;0;FLOAT4;0,0,0,0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;58;-277.6083,1454.767;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT4;0,0,0,0;False;2;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.CommentaryNode;3;461.7161,680.2491;Inherit;False;617.5722;357.2172;Tesselation;4;7;6;5;4;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;27;-154.0152,1067.11;Inherit;False;3;3;0;FLOAT4;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
@@ -94,7 +94,7 @@ Node;AmplifyShaderEditor.RangedFloatNode;2;-673.7815,769.8032;Inherit;False;Prop
 Node;AmplifyShaderEditor.DistanceBasedTessNode;7;831.289,792.1249;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.RangedFloatNode;6;648.784,824.708;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.RangedFloatNode;4;647.774,921.4664;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;1;-273.8732,633.3308;Inherit;False;Property;_Albedo;Albedo;1;0;Create;True;0;0;0;False;0;False;0.282353,0.8666667,0.8235294,1;0.9333333,0.6901961,0.2078429,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ColorNode;1;-273.8732,633.3308;Inherit;False;Property;_Color;Color;1;0;Create;True;0;0;0;False;0;False;0.282353,0.8666667,0.8235294,1;0.9333333,0.6901961,0.2078429,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;165.0051,794.8578;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreCrystalNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
 WireConnection;50;0;10;0
 WireConnection;20;0;17;0
@@ -103,10 +103,10 @@ WireConnection;56;0;20;0
 WireConnection;56;2;20;2
 WireConnection;26;0;20;1
 WireConnection;26;1;54;0
-WireConnection;48;0;10;0
-WireConnection;48;4;61;0
 WireConnection;47;0;26;0
 WireConnection;57;0;56;0
+WireConnection;48;0;10;0
+WireConnection;48;4;61;0
 WireConnection;58;0;60;0
 WireConnection;58;1;57;0
 WireConnection;58;2;10;0
@@ -126,4 +126,4 @@ WireConnection;0;3;2;0
 WireConnection;0;4;2;0
 WireConnection;0;11;59;0
 ASEEND*/
-//CHKSM=AE6B5DA8591BCCE908EB1FCD35DD1B3297C3BCDB
+//CHKSM=F6D0B375B37FA1F1463F6A02931E6E1EB3124252

--- a/Assets/Entities/Ore/Shader_OreCrystalNew.shader
+++ b/Assets/Entities/Ore/Shader_OreCrystalNew.shader
@@ -1,0 +1,129 @@
+// Upgrade NOTE: upgraded instancing buffer 'Shader_OreCrystalNew' to new syntax.
+
+// Made with Amplify Shader Editor
+// Available at the Unity Asset Store - http://u3d.as/y3X 
+Shader "Shader_OreCrystalNew"
+{
+	Properties
+	{
+		_SmoothnessMetallic("Smoothness+Metallic", Range( 0 , 1)) = 0.383
+		_Albedo("Albedo", Color) = (0.282353,0.8666667,0.8235294,1)
+		_DamageFac("DamageFac", Range( 0 , 1)) = 0
+		_DamageInsetMultiplier("DamageInsetMultiplier", Range( -1 , 1)) = -0.18
+		_DamageScaleMultiplier("DamageScaleMultiplier", Range( -2 , 2)) = -0.05
+		[HideInInspector] __dirty( "", Int ) = 1
+	}
+
+	SubShader
+	{
+		Tags{ "RenderType" = "Opaque"  "Queue" = "Geometry+0" }
+		Cull Back
+		CGPROGRAM
+		#pragma target 4.6
+		#pragma multi_compile_instancing
+		#pragma surface surf Standard keepalpha addshadow fullforwardshadows vertex:vertexDataFunc 
+		struct Input
+		{
+			half filler;
+		};
+
+		uniform float _DamageInsetMultiplier;
+		uniform float _DamageScaleMultiplier;
+		uniform float4 _Albedo;
+		uniform float _SmoothnessMetallic;
+
+		UNITY_INSTANCING_BUFFER_START(Shader_OreCrystalNew)
+			UNITY_DEFINE_INSTANCED_PROP(float, _DamageFac)
+#define _DamageFac_arr Shader_OreCrystalNew
+		UNITY_INSTANCING_BUFFER_END(Shader_OreCrystalNew)
+
+		void vertexDataFunc( inout appdata_full v, out Input o )
+		{
+			UNITY_INITIALIZE_OUTPUT( Input, o );
+			float4 appendResult12 = (float4(0.0 , 1.0 , 0.0 , 0.0));
+			float _DamageFac_Instance = UNITY_ACCESS_INSTANCED_PROP(_DamageFac_arr, _DamageFac);
+			float3 ase_vertex3Pos = v.vertex.xyz;
+			float3 break20 = ase_vertex3Pos;
+			float clampResult54 = clamp( (0.7 + (_DamageFac_Instance - 0.0) * (0.4 - 0.7) / (1.0 - 0.0)) , 0.0 , 1.0 );
+			float clampResult47 = clamp( (0.0 + (break20.y - clampResult54) * (0.5 - 0.0) / (0.73 - clampResult54)) , 0.0 , 1.0 );
+			float4 appendResult56 = (float4(break20.x , 0.0 , break20.z , 0.0));
+			float4 normalizeResult57 = normalize( appendResult56 );
+			v.vertex.xyz += ( ( appendResult12 * (0.0 + (_DamageFac_Instance - 0.0) * (_DamageInsetMultiplier - 0.0) / (1.0 - 0.0)) * clampResult47 ) + ( _DamageScaleMultiplier * normalizeResult57 * _DamageFac_Instance ) ).xyz;
+			v.vertex.w = 1;
+		}
+
+		void surf( Input i , inout SurfaceOutputStandard o )
+		{
+			o.Albedo = _Albedo.rgb;
+			float temp_output_2_0 = _SmoothnessMetallic;
+			o.Metallic = temp_output_2_0;
+			o.Smoothness = temp_output_2_0;
+			o.Alpha = 1;
+		}
+
+		ENDCG
+	}
+	Fallback "Diffuse"
+	CustomEditor "ASEMaterialInspector"
+}
+/*ASEBEGIN
+Version=18935
+679;503;1880;1021;1462.574;-839.7872;1;True;True
+Node;AmplifyShaderEditor.CommentaryNode;49;-988.8012,916.2682;Inherit;False;996.7859;503.8422;Use 'Damage Factor' to lerp the highest vertices down;9;17;20;26;47;10;48;12;27;61;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.RangedFloatNode;10;-946.8012,955.2682;Inherit;False;InstancedProperty;_DamageFac;DamageFac;2;0;Create;True;0;0;0;False;0;False;0;0;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;50;-1057.222,1488.258;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0.7;False;4;FLOAT;0.4;False;1;FLOAT;0
+Node;AmplifyShaderEditor.PosVertexDataNode;17;-938.45,1162.241;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.BreakToComponentsNode;20;-747.4497,1163.241;Inherit;False;FLOAT3;1;0;FLOAT3;0,0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.ClampOpNode;54;-776.2219,1490.258;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;56;-587.6083,1452.767;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.RangedFloatNode;61;-948.6083,1052.767;Inherit;False;Property;_DamageInsetMultiplier;DamageInsetMultiplier;3;0;Create;True;0;0;0;False;0;False;-0.18;0;-1;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;26;-610.015,1166.11;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.7;False;2;FLOAT;0.73;False;3;FLOAT;0;False;4;FLOAT;0.5;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;12;-330.858,1007.186;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.TFHCRemapNode;48;-642.6004,968.8472;Inherit;False;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;-0.6;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;60;-610.6083,1619.767;Inherit;False;Property;_DamageScaleMultiplier;DamageScaleMultiplier;4;0;Create;True;0;0;0;False;0;False;-0.05;-0.05;-2;2;0;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;47;-339.6006,1165.847;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalizeNode;57;-451.6083,1452.767;Inherit;False;False;1;0;FLOAT4;0,0,0,0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;58;-277.6083,1454.767;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT4;0,0,0,0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.CommentaryNode;3;461.7161,680.2491;Inherit;False;617.5722;357.2172;Tesselation;4;7;6;5;4;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;27;-154.0152,1067.11;Inherit;False;3;3;0;FLOAT4;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SimpleAddOpNode;59;11.39172,1181.767;Inherit;False;2;2;0;FLOAT4;0,0,0,0;False;1;FLOAT4;0,0,0,0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.OneMinusNode;52;-1368.222,1485.258;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;5;511.716,730.2493;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;53;-1208.222,1487.258;Inherit;False;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;2;-673.7815,769.8032;Inherit;False;Property;_SmoothnessMetallic;Smoothness+Metallic;0;0;Create;True;0;0;0;False;0;False;0.383;0.383;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.DistanceBasedTessNode;7;831.289,792.1249;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.RangedFloatNode;6;648.784,824.708;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;4;647.774,921.4664;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;1;-273.8732,633.3308;Inherit;False;Property;_Albedo;Albedo;1;0;Create;True;0;0;0;False;0;False;0.282353,0.8666667,0.8235294,1;0.9333333,0.6901961,0.2078429,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;165.0051,794.8578;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreCrystalNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
+WireConnection;50;0;10;0
+WireConnection;20;0;17;0
+WireConnection;54;0;50;0
+WireConnection;56;0;20;0
+WireConnection;56;2;20;2
+WireConnection;26;0;20;1
+WireConnection;26;1;54;0
+WireConnection;48;0;10;0
+WireConnection;48;4;61;0
+WireConnection;47;0;26;0
+WireConnection;57;0;56;0
+WireConnection;58;0;60;0
+WireConnection;58;1;57;0
+WireConnection;58;2;10;0
+WireConnection;27;0;12;0
+WireConnection;27;1;48;0
+WireConnection;27;2;47;0
+WireConnection;59;0;27;0
+WireConnection;59;1;58;0
+WireConnection;52;0;10;0
+WireConnection;53;0;52;0
+WireConnection;53;1;52;0
+WireConnection;7;0;5;0
+WireConnection;7;1;6;0
+WireConnection;7;2;4;0
+WireConnection;0;0;1;0
+WireConnection;0;3;2;0
+WireConnection;0;4;2;0
+WireConnection;0;11;59;0
+ASEEND*/
+//CHKSM=AE6B5DA8591BCCE908EB1FCD35DD1B3297C3BCDB

--- a/Assets/Entities/Ore/Shader_OreCrystalNew.shader.meta
+++ b/Assets/Entities/Ore/Shader_OreCrystalNew.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1df71dc43c1ae464a80657ff347370b0
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Entities/Ore/Shader_OreNew.shader
+++ b/Assets/Entities/Ore/Shader_OreNew.shader
@@ -7,7 +7,7 @@ Shader "Shader_OreNew"
 	Properties
 	{
 		_Albedo("Albedo", Color) = (0.5566038,0.4088009,0.2599235,1)
-		_CrackLightness("Crack Lightness", Color) = (1,1,1,1)
+		_CrackAlbedo("Crack Albedo", Color) = (1,1,1,1)
 		_Float2("Float 2", Float) = -1
 		_CritPosition("Crit Position", Vector) = (0,0,0,0)
 		_CrackPosition0("Crack Position 0", Vector) = (0,0,0,0)
@@ -33,8 +33,8 @@ Shader "Shader_OreNew"
 		};
 
 		uniform float _Float2;
+		uniform float4 _CrackAlbedo;
 		uniform float4 _Albedo;
-		uniform float4 _CrackLightness;
 
 		UNITY_INSTANCING_BUFFER_START(Shader_OreNew)
 			UNITY_DEFINE_INSTANCED_PROP(float3, _CrackPosition0)
@@ -135,10 +135,8 @@ return F1;
 
 		void surf( Input i , inout SurfaceOutputStandard o )
 		{
-			float4 blendOpSrc8 = _Albedo;
-			float4 blendOpDest8 = _CrackLightness;
-			float4 blendOpSrc3 = _Albedo;
-			float4 blendOpDest3 = ( saturate( min( blendOpSrc8 , blendOpDest8 ) ));
+			float4 blendOpSrc3 = _CrackAlbedo;
+			float4 blendOpDest3 = _Albedo;
 			float3 objToWorld53 = mul( unity_ObjectToWorld, float4( float3( 0,0,0 ), 1 ) ).xyz;
 			float dotResult4_g5 = dot( objToWorld53.xy , float2( 12.9898,78.233 ) );
 			float lerpResult10_g5 = lerp( 0.0 , 10.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
@@ -151,17 +149,16 @@ return F1;
 			float voroi1 = voronoi1( coords1, time1, id1, uv1, 0, voronoiSmoothId1 );
 			float temp_output_5_0 = ( 1.0 - voroi1 );
 			float clampResult6 = clamp( temp_output_5_0 , 0.0 , 1.0 );
-			float4 lerpBlendMode3 = lerp(blendOpDest3,( blendOpSrc3 * blendOpDest3 ),clampResult6);
+			float4 lerpBlendMode3 = lerp(blendOpDest3,min( blendOpSrc3 , blendOpDest3 ),clampResult6);
 			float div12=256.0/float(2);
 			float4 posterize12 = ( floor( ( saturate( lerpBlendMode3 )) * div12 ) / div12 );
 			float4 color76 = IsGammaSpace() ? float4(0.1981132,0.1132669,0.06448024,1) : float4(0.03251993,0.01220649,0.005366667,1);
 			float4 blendOpSrc28 = posterize12;
 			float4 blendOpDest28 = color76;
-			float3 ase_vertex3Pos = mul( unity_WorldToObject, float4( i.worldPos , 1 ) );
-			float3 normalizeResult68 = normalize( abs( ase_vertex3Pos ) );
-			float dotResult69 = dot( normalizeResult68 , float3( 0,1,0 ) );
-			float4 lerpBlendMode28 = lerp(blendOpDest28,	max( blendOpSrc28, blendOpDest28 ),( dotResult69 * dotResult69 ));
+			float clampResult153 = clamp( (-1.3 + (distance( i.uv_texcoord , float2( 0.5,0.5 ) ) - 1.0) * (1.0 - -1.3) / (0.0 - 1.0)) , 0.0 , 1.0 );
+			float4 lerpBlendMode28 = lerp(blendOpDest28,	max( blendOpSrc28, blendOpDest28 ),clampResult153);
 			float temp_output_45_0 = (0.0 + (temp_output_5_0 - 0.9) * (1.0 - 0.0) / (1.0 - 0.9));
+			float3 ase_vertex3Pos = mul( unity_WorldToObject, float4( i.worldPos , 1 ) );
 			float3 normalizeResult35 = normalize( ase_vertex3Pos );
 			float3 temp_output_87_0 = ( normalizeResult35 * float3( 1,1,1 ) );
 			float3 _CrackPosition0_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition0_arr, _CrackPosition0);
@@ -199,186 +196,180 @@ return F1;
 }
 /*ASEBEGIN
 Version=18935
-1100;220;1927;1104;2058.025;-568.2964;1;True;True
+1048;144;1596;1104;2017.179;-1369.433;1;True;True
 Node;AmplifyShaderEditor.CommentaryNode;66;-1590.128,325.1008;Inherit;False;1965.974;811.125;Comment;6;42;43;52;46;65;64;Critical cracks;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;64;-1540.128,702.3971;Inherit;False;958.6241;400.45;Mask towards "Crit Position";6;31;16;35;26;25;36;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;128;-1979.118,1283;Inherit;False;1991.234;1102.633;Comment;10;97;94;98;87;146;145;144;101;79;89;Mask Crack Positions;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;101;-1553.33,2057.073;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;79;-1546.36,1448.83;Inherit;False;1062.152;287.2551;Mask towards "Crack Position 0";5;99;85;82;80;84;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.PosVertexDataNode;31;-1490.128,752.3972;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;6;0;Create;True;0;0;0;True;0;False;0,0,0;-0.6,0.2,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1242.101;710.6329;Comment;8;1;6;5;62;137;138;139;140;Voronoi;1,1,1,1;0;0
-Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;5;0;Create;True;0;0;0;True;0;False;0,0,0;0.3,0.7,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;4;0;Create;True;0;0;0;True;0;False;0,0,0;0,1,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;4;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.NormalizeNode;35;-1289.127,821.7971;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world position;2;53;24;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1339.392,1333;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.NormalizeNode;82;-1307.487,1570.18;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1339.392,1333;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world position;2;53;24;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.DotProductOpNode;106;-1144.822,2110.755;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TransformPositionNode;53;-2162.797,-361.0663;Inherit;False;Object;World;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;8;28;12;8;2;9;3;71;129;Base Color;1,1,1,1;0;0
-Node;AmplifyShaderEditor.TransformPositionNode;53;-2162.797,-361.0663;Inherit;False;Object;World;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-761.7249;Inherit;False;1155.794;301.5989;Darken edges;6;73;69;68;72;67;76;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;10;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;85;-919.8392,1500.682;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Constant;_VoronoiScale;Voronoi Scale;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.PosVertexDataNode;67;-492.7229,-710.407;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;10;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;99;-641.5961,1504.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
-Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.ClampOpNode;100;-649.5961,1807.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,1,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.AbsOpNode;72;-314.0877,-707.6897;Inherit;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackLightness;Crack Lightness;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.NormalizeNode;68;-315.7218,-634.0073;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.BlendOpsNode;8;-544.1525,-411.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;7;28;12;2;9;3;71;129;Base Color;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.TextureCoordinatesNode;148;-523.285,-746.3354;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0.4470588,0.3254901,0.2078431,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.5566037,0.4088006,0.2599232,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SmoothstepOpNode;55;-836.9797,425.101;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DotProductOpNode;69;-141.9087,-712.7249;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,1,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;36;-871.5046,826.2494;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-802.0814;Inherit;False;1155.794;361.0718;Darken edges;1;76;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
-Node;AmplifyShaderEditor.ColorNode;76;342.1132,-697.6896;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ColorNode;76;342.1132,-738.046;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;46;-447.7533,611.8972;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
 Node;AmplifyShaderEditor.ClampOpNode;110;261.662,-104.9208;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;73;78.91205,-712.6898;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;-1;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;153;191.1495,-739.3545;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
 Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.VoronoiNode;137;-1666.739,-94.47645;Inherit;True;0;0;1;0;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
-Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;15;0;1;32;0;1;FLOAT;0
-Node;AmplifyShaderEditor.OneMinusNode;140;-1475.196,-93.95569;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
-Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.TFHCRemapNode;139;-1280.196,-95.95569;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.78;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
+Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;-0.74;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
-Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
+Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
+Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.VoronoiNode;137;-1666.739,-94.47645;Inherit;True;0;0;1;0;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
+Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TransformPositionNode;126;2086.822,1073.477;Inherit;False;World;Object;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.OneMinusNode;140;-1475.196,-93.95569;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.TFHCRemapNode;139;-1280.196,-95.95569;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.78;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;0;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
 WireConnection;35;0;31;0
-WireConnection;93;0;92;0
-WireConnection;102;0;103;0
-WireConnection;87;0;35;0
 WireConnection;82;0;80;0
+WireConnection;87;0;35;0
+WireConnection;102;0;103;0
+WireConnection;93;0;92;0
 WireConnection;106;0;87;0
 WireConnection;106;1;102;0
 WireConnection;84;0;87;0
 WireConnection;84;1;82;0
 WireConnection;91;0;87;0
 WireConnection;91;1;93;0
-WireConnection;90;0;91;0
-WireConnection;90;1;98;0
-WireConnection;24;1;53;0
 WireConnection;85;0;84;0
 WireConnection;85;1;98;0
+WireConnection;90;0;91;0
+WireConnection;90;1;98;0
 WireConnection;104;0;106;0
 WireConnection;104;1;98;0
+WireConnection;24;1;53;0
+WireConnection;105;0;104;0
 WireConnection;99;0;85;0
 WireConnection;1;1;24;0
 WireConnection;1;2;138;0
-WireConnection;105;0;104;0
 WireConnection;100;0;90;0
-WireConnection;72;0;67;0
+WireConnection;5;0;1;0
 WireConnection;26;0;25;0
 WireConnection;94;0;99;0
 WireConnection;94;1;100;0
 WireConnection;94;2;105;0
-WireConnection;5;0;1;0
+WireConnection;45;0;5;0
+WireConnection;150;0;148;0
 WireConnection;6;0;5;0
+WireConnection;97;0;94;0
 WireConnection;16;0;35;0
 WireConnection;16;1;26;0
-WireConnection;68;0;72;0
-WireConnection;8;0;2;0
-WireConnection;8;1;9;0
-WireConnection;97;0;94;0
-WireConnection;45;0;5;0
 WireConnection;55;0;45;0
-WireConnection;69;0;68;0
+WireConnection;152;0;150;0
 WireConnection;36;0;16;0
 WireConnection;107;0;45;0
 WireConnection;107;1;97;0
-WireConnection;3;0;2;0
-WireConnection;3;1;8;0
+WireConnection;3;0;9;0
+WireConnection;3;1;2;0
 WireConnection;3;2;6;0
 WireConnection;46;0;55;0
 WireConnection;46;1;36;0
-WireConnection;12;1;3;0
 WireConnection;110;0;107;0
-WireConnection;73;0;69;0
-WireConnection;73;1;69;0
+WireConnection;153;0;152;0
+WireConnection;12;1;3;0
+WireConnection;52;0;46;0
 WireConnection;108;0;110;0
 WireConnection;28;0;12;0
 WireConnection;28;1;76;0
-WireConnection;28;2;73;0
-WireConnection;52;0;46;0
+WireConnection;28;2;153;0
+WireConnection;121;0;120;1
 WireConnection;141;0;142;0
 WireConnection;141;1;136;0
-WireConnection;120;0;118;0
-WireConnection;113;0;110;0
-WireConnection;113;1;114;0
-WireConnection;113;2;112;0
-WireConnection;42;0;43;0
-WireConnection;42;1;52;0
 WireConnection;137;1;24;0
 WireConnection;137;2;138;0
 WireConnection;119;0;120;0
-WireConnection;121;0;120;1
-WireConnection;140;0;137;0
 WireConnection;118;0;1;1
 WireConnection;118;1;97;0
-WireConnection;54;0;115;0
-WireConnection;54;1;116;0
-WireConnection;54;2;117;0
-WireConnection;139;0;140;0
+WireConnection;136;0;119;0
+WireConnection;126;0;125;0
 WireConnection;122;0;141;0
 WireConnection;122;1;114;0
 WireConnection;122;2;112;0
-WireConnection;136;0;119;0
 WireConnection;135;1;118;0
+WireConnection;113;0;110;0
+WireConnection;113;1;114;0
+WireConnection;113;2;112;0
+WireConnection;120;0;118;0
+WireConnection;42;0;43;0
+WireConnection;42;1;52;0
+WireConnection;140;0;137;0
 WireConnection;142;0;1;0
+WireConnection;54;0;115;0
+WireConnection;54;1;116;0
+WireConnection;54;2;117;0
 WireConnection;109;0;28;0
 WireConnection;109;1;108;0
-WireConnection;126;0;125;0
+WireConnection;139;0;140;0
 WireConnection;0;0;109;0
 WireConnection;0;2;42;0
 WireConnection;0;11;113;0
 ASEEND*/
-//CHKSM=0D8DD9C3E894F5A813699F962FEF570DE8D8B4F5
+//CHKSM=438A137BB7E875AAFBB49D9DECFB0E38A5A763F1

--- a/Assets/Entities/Ore/Shader_OreNew.shader
+++ b/Assets/Entities/Ore/Shader_OreNew.shader
@@ -196,160 +196,168 @@ return F1;
 }
 /*ASEBEGIN
 Version=18935
-1048;144;1596;1104;2017.179;-1369.433;1;True;True
+605;166;1596;1098;2133.071;-1630.235;1;True;True
 Node;AmplifyShaderEditor.CommentaryNode;66;-1590.128,325.1008;Inherit;False;1965.974;811.125;Comment;6;42;43;52;46;65;64;Critical cracks;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;64;-1540.128,702.3971;Inherit;False;958.6241;400.45;Mask towards "Crit Position";6;31;16;35;26;25;36;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;128;-1979.118,1283;Inherit;False;1991.234;1102.633;Comment;10;97;94;98;87;146;145;144;101;79;89;Mask Crack Positions;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;101;-1553.33,2057.073;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;79;-1546.36,1448.83;Inherit;False;1062.152;287.2551;Mask towards "Crack Position 0";5;99;85;82;80;84;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.PosVertexDataNode;31;-1490.128,752.3972;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1242.101;710.6329;Comment;8;1;6;5;62;137;138;139;140;Voronoi;1,1,1,1;0;0
-Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;4;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.CommentaryNode;101;-1553.33,2057.073;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.NormalizeNode;35;-1289.127,821.7971;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1242.101;710.6329;Comment;8;1;6;5;62;137;138;139;140;Voronoi;1,1,1,1;0;0
+Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;4;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.NormalizeNode;82;-1307.487,1570.18;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1339.392,1333;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world position;2;53;24;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.DotProductOpNode;106;-1144.822,2110.755;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TransformPositionNode;53;-2162.797,-361.0663;Inherit;False;Object;World;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;85;-919.8392,1500.682;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Constant;_VoronoiScale;Voronoi Scale;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;10;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;99;-641.5961,1504.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Constant;_VoronoiScale;Voronoi Scale;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;85;-919.8392,1500.682;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
 Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.ClampOpNode;99;-641.5961,1504.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;100;-649.5961,1807.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;7;28;12;2;9;3;71;129;Base Color;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.TextureCoordinatesNode;148;-523.285,-746.3354;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0.4470588,0.3254901,0.2078431,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.5566037,0.4088006,0.2599232,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;7;28;12;2;9;3;71;129;Base Color;1,1,1,1;0;0
+Node;AmplifyShaderEditor.TextureCoordinatesNode;148;-523.285,-746.3354;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;55;-836.9797,425.101;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.5566037,0.4088006,0.2599232,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0.4470588,0.3254901,0.2078431,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;36;-871.5046,826.2494;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;55;-836.9797,425.101;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-802.0814;Inherit;False;1155.794;361.0718;Darken edges;1;76;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ColorNode;76;342.1132,-738.046;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;46;-447.7533,611.8972;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;110;261.662,-104.9208;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;153;191.1495,-739.3545;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
-Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
 Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;-0.74;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
-Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
-Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.VoronoiNode;137;-1666.739,-94.47645;Inherit;True;0;0;1;0;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
-Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
-Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
 Node;AmplifyShaderEditor.TransformPositionNode;126;2086.822,1073.477;Inherit;False;World;Object;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
-Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.OneMinusNode;140;-1475.196,-93.95569;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;139;-1280.196,-95.95569;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.78;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;0;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
+Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.OneMinusNode;140;-1475.196,-93.95569;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
 WireConnection;35;0;31;0
+WireConnection;93;0;92;0
+WireConnection;102;0;103;0
 WireConnection;82;0;80;0
 WireConnection;87;0;35;0
-WireConnection;102;0;103;0
-WireConnection;93;0;92;0
+WireConnection;91;0;87;0
+WireConnection;91;1;93;0
 WireConnection;106;0;87;0
 WireConnection;106;1;102;0
 WireConnection;84;0;87;0
 WireConnection;84;1;82;0
-WireConnection;91;0;87;0
-WireConnection;91;1;93;0
-WireConnection;85;0;84;0
-WireConnection;85;1;98;0
-WireConnection;90;0;91;0
-WireConnection;90;1;98;0
 WireConnection;104;0;106;0
 WireConnection;104;1;98;0
 WireConnection;24;1;53;0
-WireConnection;105;0;104;0
-WireConnection;99;0;85;0
+WireConnection;90;0;91;0
+WireConnection;90;1;98;0
+WireConnection;85;0;84;0
+WireConnection;85;1;98;0
 WireConnection;1;1;24;0
 WireConnection;1;2;138;0
+WireConnection;99;0;85;0
 WireConnection;100;0;90;0
-WireConnection;5;0;1;0
+WireConnection;105;0;104;0
 WireConnection;26;0;25;0
+WireConnection;5;0;1;0
 WireConnection;94;0;99;0
 WireConnection;94;1;100;0
 WireConnection;94;2;105;0
+WireConnection;16;0;35;0
+WireConnection;16;1;26;0
+WireConnection;97;0;94;0
 WireConnection;45;0;5;0
 WireConnection;150;0;148;0
 WireConnection;6;0;5;0
-WireConnection;97;0;94;0
-WireConnection;16;0;35;0
-WireConnection;16;1;26;0
-WireConnection;55;0;45;0
-WireConnection;152;0;150;0
 WireConnection;36;0;16;0
-WireConnection;107;0;45;0
-WireConnection;107;1;97;0
+WireConnection;55;0;45;0
 WireConnection;3;0;9;0
 WireConnection;3;1;2;0
 WireConnection;3;2;6;0
+WireConnection;107;0;45;0
+WireConnection;107;1;97;0
+WireConnection;152;0;150;0
 WireConnection;46;0;55;0
 WireConnection;46;1;36;0
 WireConnection;110;0;107;0
 WireConnection;153;0;152;0
 WireConnection;12;1;3;0
 WireConnection;52;0;46;0
-WireConnection;108;0;110;0
 WireConnection;28;0;12;0
 WireConnection;28;1;76;0
 WireConnection;28;2;153;0
+WireConnection;108;0;110;0
+WireConnection;136;0;119;0
 WireConnection;121;0;120;1
+WireConnection;119;0;120;0
+WireConnection;118;0;1;1
+WireConnection;118;1;97;0
+WireConnection;54;0;115;0
+WireConnection;54;1;116;0
+WireConnection;54;2;117;0
 WireConnection;141;0;142;0
 WireConnection;141;1;136;0
 WireConnection;137;1;24;0
 WireConnection;137;2;138;0
-WireConnection;119;0;120;0
-WireConnection;118;0;1;1
-WireConnection;118;1;97;0
-WireConnection;136;0;119;0
+WireConnection;109;0;28;0
+WireConnection;109;1;108;0
 WireConnection;126;0;125;0
+WireConnection;120;0;118;0
+WireConnection;42;0;43;0
+WireConnection;42;1;52;0
 WireConnection;122;0;141;0
 WireConnection;122;1;114;0
 WireConnection;122;2;112;0
@@ -357,19 +365,11 @@ WireConnection;135;1;118;0
 WireConnection;113;0;110;0
 WireConnection;113;1;114;0
 WireConnection;113;2;112;0
-WireConnection;120;0;118;0
-WireConnection;42;0;43;0
-WireConnection;42;1;52;0
-WireConnection;140;0;137;0
-WireConnection;142;0;1;0
-WireConnection;54;0;115;0
-WireConnection;54;1;116;0
-WireConnection;54;2;117;0
-WireConnection;109;0;28;0
-WireConnection;109;1;108;0
 WireConnection;139;0;140;0
+WireConnection;142;0;1;0
+WireConnection;140;0;137;0
 WireConnection;0;0;109;0
 WireConnection;0;2;42;0
 WireConnection;0;11;113;0
 ASEEND*/
-//CHKSM=438A137BB7E875AAFBB49D9DECFB0E38A5A763F1
+//CHKSM=FCE4C5773CA0D8991441871F930527413BF88F83

--- a/Assets/Entities/Ore/Shader_OreNew.shader
+++ b/Assets/Entities/Ore/Shader_OreNew.shader
@@ -10,6 +10,7 @@ Shader "Shader_OreNew"
 		_CrackAlbedo("Crack Albedo", Color) = (1,1,1,1)
 		_Float2("Float 2", Float) = -1
 		_CritPosition("Crit Position", Vector) = (0,0,0,0)
+		_VoronoiScale("Voronoi Scale", Float) = 5
 		_CrackPosition0("Crack Position 0", Vector) = (0,0,0,0)
 		_CrackPosition1("Crack Position 1", Vector) = (0,0,0,0)
 		_CrackPosition2("Crack Position 2", Vector) = (0,0,0,0)
@@ -32,6 +33,7 @@ Shader "Shader_OreNew"
 			float3 worldPos;
 		};
 
+		uniform float _VoronoiScale;
 		uniform float _Float2;
 		uniform float4 _CrackAlbedo;
 		uniform float4 _Albedo;
@@ -99,13 +101,11 @@ return F1;
 		void vertexDataFunc( inout appdata_full v, out Input o )
 		{
 			UNITY_INITIALIZE_OUTPUT( Input, o );
-			float3 objToWorld53 = mul( unity_ObjectToWorld, float4( float3( 0,0,0 ), 1 ) ).xyz;
-			float dotResult4_g5 = dot( objToWorld53.xy , float2( 12.9898,78.233 ) );
-			float lerpResult10_g5 = lerp( 0.0 , 10.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
-			float temp_output_24_0 = lerpResult10_g5;
-			float time1 = temp_output_24_0;
+			float dotResult4_g5 = dot( float2( 0,0 ) , float2( 12.9898,78.233 ) );
+			float lerpResult10_g5 = lerp( 0.0 , 20.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
+			float time1 = lerpResult10_g5;
 			float2 voronoiSmoothId1 = 0;
-			float2 coords1 = v.texcoord.xy * 5.0;
+			float2 coords1 = v.texcoord.xy * _VoronoiScale;
 			float2 id1 = 0;
 			float2 uv1 = 0;
 			float voroi1 = voronoi1( coords1, time1, id1, uv1, 0, voronoiSmoothId1 );
@@ -137,13 +137,11 @@ return F1;
 		{
 			float4 blendOpSrc3 = _CrackAlbedo;
 			float4 blendOpDest3 = _Albedo;
-			float3 objToWorld53 = mul( unity_ObjectToWorld, float4( float3( 0,0,0 ), 1 ) ).xyz;
-			float dotResult4_g5 = dot( objToWorld53.xy , float2( 12.9898,78.233 ) );
-			float lerpResult10_g5 = lerp( 0.0 , 10.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
-			float temp_output_24_0 = lerpResult10_g5;
-			float time1 = temp_output_24_0;
+			float dotResult4_g5 = dot( float2( 0,0 ) , float2( 12.9898,78.233 ) );
+			float lerpResult10_g5 = lerp( 0.0 , 20.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
+			float time1 = lerpResult10_g5;
 			float2 voronoiSmoothId1 = 0;
-			float2 coords1 = i.uv_texcoord * 5.0;
+			float2 coords1 = i.uv_texcoord * _VoronoiScale;
 			float2 id1 = 0;
 			float2 uv1 = 0;
 			float voroi1 = voronoi1( coords1, time1, id1, uv1, 0, voronoiSmoothId1 );
@@ -182,9 +180,9 @@ return F1;
 			float3 normalizeResult26 = normalize( _CritPosition_Instance );
 			float dotResult16 = dot( normalizeResult35 , normalizeResult26 );
 			float clampResult52 = clamp( ( smoothstepResult55 * (0.0 + (dotResult16 - 0.95) * (1.0 - 0.0) / (1.0 - 0.95)) ) , 0.0 , 1.0 );
-			float4 temp_cast_2 = (clampResult52).xxxx;
+			float4 temp_cast_1 = (clampResult52).xxxx;
 			float4 blendOpSrc42 = color43;
-			float4 blendOpDest42 = temp_cast_2;
+			float4 blendOpDest42 = temp_cast_1;
 			o.Emission = ( saturate( ( blendOpSrc42 * blendOpDest42 ) )).rgb;
 			o.Alpha = 1;
 		}
@@ -196,7 +194,7 @@ return F1;
 }
 /*ASEBEGIN
 Version=18935
-605;166;1596;1098;2133.071;-1630.235;1;True;True
+648;249;1729;955;2601.67;795.2008;1;True;True
 Node;AmplifyShaderEditor.CommentaryNode;66;-1590.128,325.1008;Inherit;False;1965.974;811.125;Comment;6;42;43;52;46;65;64;Critical cracks;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;64;-1540.128,702.3971;Inherit;False;958.6241;400.45;Mask towards "Crit Position";6;31;16;35;26;25;36;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;128;-1979.118,1283;Inherit;False;1991.234;1102.633;Comment;10;97;94;98;87;146;145;144;101;79;89;Mask Crack Positions;1,1,1,1;0;0
@@ -204,172 +202,164 @@ Node;AmplifyShaderEditor.CommentaryNode;79;-1546.36,1448.83;Inherit;False;1062.1
 Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.PosVertexDataNode;31;-1490.128,752.3972;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.CommentaryNode;101;-1553.33,2057.073;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;7;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.NormalizeNode;35;-1289.127,821.7971;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1242.101;710.6329;Comment;8;1;6;5;62;137;138;139;140;Voronoi;1,1,1,1;0;0
-Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;4;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1242.101;710.6329;Comment;5;1;6;5;62;138;Voronoi;1,1,1,1;0;0
 Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;82;-1307.487,1570.18;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1339.392,1333;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;82;-1307.487,1570.18;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world position;2;53;24;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.DotProductOpNode;106;-1144.822,2110.755;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TransformPositionNode;53;-2162.797,-361.0663;Inherit;False;Object;World;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;10;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Constant;_VoronoiScale;Voronoi Scale;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Property;_VoronoiScale;Voronoi Scale;4;0;Create;True;0;0;0;False;0;False;5;7;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;20;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;85;-919.8392,1500.682;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
-Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.ClampOpNode;99;-641.5961,1504.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;100;-649.5961,1807.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
 Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;7;28;12;2;9;3;71;129;Base Color;1,1,1,1;0;0
 Node;AmplifyShaderEditor.TextureCoordinatesNode;148;-523.285,-746.3354;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.5566037,0.4088006,0.2599232,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0.595,0.5367935,0.4656522,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0.4470588,0.3254901,0.2078431,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.794,0.7201173,0.642346,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-802.0814;Inherit;False;1155.794;361.0718;Darken edges;1;76;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;36;-871.5046,826.2494;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SmoothstepOpNode;55;-836.9797,425.101;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-802.0814;Inherit;False;1155.794;361.0718;Darken edges;1;76;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;76;342.1132,-738.046;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;46;-447.7533,611.8972;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;110;261.662,-104.9208;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;76;342.1132,-738.046;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.ClampOpNode;153;191.1495,-739.3545;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
 Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
-Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;-0.74;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
 Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
-Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.VoronoiNode;137;-1666.739,-94.47645;Inherit;True;0;0;1;0;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
-Node;AmplifyShaderEditor.TransformPositionNode;126;2086.822,1073.477;Inherit;False;World;Object;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
-Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
-Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
+Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;139;-1280.196,-95.95569;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.78;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.OneMinusNode;140;-1475.196,-93.95569;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
 Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TransformPositionNode;53;-2162.797,-361.0663;Inherit;False;Object;World;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.TransformPositionNode;126;2086.822,1073.477;Inherit;False;World;Object;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
 WireConnection;35;0;31;0
-WireConnection;93;0;92;0
 WireConnection;102;0;103;0
-WireConnection;82;0;80;0
+WireConnection;93;0;92;0
 WireConnection;87;0;35;0
+WireConnection;82;0;80;0
+WireConnection;84;0;87;0
+WireConnection;84;1;82;0
 WireConnection;91;0;87;0
 WireConnection;91;1;93;0
 WireConnection;106;0;87;0
 WireConnection;106;1;102;0
-WireConnection;84;0;87;0
-WireConnection;84;1;82;0
-WireConnection;104;0;106;0
-WireConnection;104;1;98;0
-WireConnection;24;1;53;0
 WireConnection;90;0;91;0
 WireConnection;90;1;98;0
+WireConnection;104;0;106;0
+WireConnection;104;1;98;0
 WireConnection;85;0;84;0
 WireConnection;85;1;98;0
-WireConnection;1;1;24;0
-WireConnection;1;2;138;0
 WireConnection;99;0;85;0
 WireConnection;100;0;90;0
+WireConnection;1;1;24;0
+WireConnection;1;2;138;0
 WireConnection;105;0;104;0
 WireConnection;26;0;25;0
 WireConnection;5;0;1;0
 WireConnection;94;0;99;0
 WireConnection;94;1;100;0
 WireConnection;94;2;105;0
+WireConnection;97;0;94;0
+WireConnection;6;0;5;0
+WireConnection;150;0;148;0
 WireConnection;16;0;35;0
 WireConnection;16;1;26;0
-WireConnection;97;0;94;0
 WireConnection;45;0;5;0
-WireConnection;150;0;148;0
-WireConnection;6;0;5;0
-WireConnection;36;0;16;0
-WireConnection;55;0;45;0
+WireConnection;152;0;150;0
 WireConnection;3;0;9;0
 WireConnection;3;1;2;0
 WireConnection;3;2;6;0
 WireConnection;107;0;45;0
 WireConnection;107;1;97;0
-WireConnection;152;0;150;0
+WireConnection;36;0;16;0
+WireConnection;55;0;45;0
 WireConnection;46;0;55;0
 WireConnection;46;1;36;0
 WireConnection;110;0;107;0
 WireConnection;153;0;152;0
 WireConnection;12;1;3;0
-WireConnection;52;0;46;0
 WireConnection;28;0;12;0
 WireConnection;28;1;76;0
 WireConnection;28;2;153;0
+WireConnection;52;0;46;0
 WireConnection;108;0;110;0
-WireConnection;136;0;119;0
-WireConnection;121;0;120;1
-WireConnection;119;0;120;0
-WireConnection;118;0;1;1
-WireConnection;118;1;97;0
 WireConnection;54;0;115;0
 WireConnection;54;1;116;0
 WireConnection;54;2;117;0
-WireConnection;141;0;142;0
-WireConnection;141;1;136;0
-WireConnection;137;1;24;0
-WireConnection;137;2;138;0
-WireConnection;109;0;28;0
-WireConnection;109;1;108;0
-WireConnection;126;0;125;0
-WireConnection;120;0;118;0
-WireConnection;42;0;43;0
-WireConnection;42;1;52;0
-WireConnection;122;0;141;0
-WireConnection;122;1;114;0
-WireConnection;122;2;112;0
-WireConnection;135;1;118;0
 WireConnection;113;0;110;0
 WireConnection;113;1;114;0
 WireConnection;113;2;112;0
-WireConnection;139;0;140;0
 WireConnection;142;0;1;0
-WireConnection;140;0;137;0
+WireConnection;109;0;28;0
+WireConnection;109;1;108;0
+WireConnection;135;1;118;0
+WireConnection;122;0;141;0
+WireConnection;122;1;114;0
+WireConnection;122;2;112;0
+WireConnection;120;0;118;0
+WireConnection;118;0;1;1
+WireConnection;118;1;97;0
+WireConnection;141;0;142;0
+WireConnection;141;1;136;0
+WireConnection;136;0;119;0
+WireConnection;119;0;120;0
+WireConnection;121;0;120;1
+WireConnection;126;0;125;0
+WireConnection;42;0;43;0
+WireConnection;42;1;52;0
 WireConnection;0;0;109;0
 WireConnection;0;2;42;0
 WireConnection;0;11;113;0
 ASEEND*/
-//CHKSM=FCE4C5773CA0D8991441871F930527413BF88F83
+//CHKSM=7E1BDD11C9BCBBA91C7EAAFF27648526886CB04D

--- a/Assets/Entities/Ore/Shader_OreNew.shader
+++ b/Assets/Entities/Ore/Shader_OreNew.shader
@@ -1,0 +1,384 @@
+// Upgrade NOTE: upgraded instancing buffer 'Shader_OreNew' to new syntax.
+
+// Made with Amplify Shader Editor
+// Available at the Unity Asset Store - http://u3d.as/y3X 
+Shader "Shader_OreNew"
+{
+	Properties
+	{
+		_Albedo("Albedo", Color) = (0.5566038,0.4088009,0.2599235,1)
+		_CrackLightness("Crack Lightness", Color) = (1,1,1,1)
+		_Float2("Float 2", Float) = -1
+		_CritPosition("Crit Position", Vector) = (0,0,0,0)
+		_CrackPosition0("Crack Position 0", Vector) = (0,0,0,0)
+		_CrackPosition1("Crack Position 1", Vector) = (0,0,0,0)
+		_CrackPosition2("Crack Position 2", Vector) = (0,0,0,0)
+		[HideInInspector] _texcoord( "", 2D ) = "white" {}
+		[HideInInspector] __dirty( "", Int ) = 1
+	}
+
+	SubShader
+	{
+		Tags{ "RenderType" = "Opaque"  "Queue" = "Geometry+0" "IsEmissive" = "true"  }
+		Cull Back
+		CGPROGRAM
+		#include "UnityShaderVariables.cginc"
+		#pragma target 4.6
+		#pragma multi_compile_instancing
+		#pragma surface surf Standard keepalpha addshadow fullforwardshadows vertex:vertexDataFunc 
+		struct Input
+		{
+			float2 uv_texcoord;
+			float3 worldPos;
+		};
+
+		uniform float _Float2;
+		uniform float4 _Albedo;
+		uniform float4 _CrackLightness;
+
+		UNITY_INSTANCING_BUFFER_START(Shader_OreNew)
+			UNITY_DEFINE_INSTANCED_PROP(float3, _CrackPosition0)
+#define _CrackPosition0_arr Shader_OreNew
+			UNITY_DEFINE_INSTANCED_PROP(float3, _CrackPosition1)
+#define _CrackPosition1_arr Shader_OreNew
+			UNITY_DEFINE_INSTANCED_PROP(float3, _CrackPosition2)
+#define _CrackPosition2_arr Shader_OreNew
+			UNITY_DEFINE_INSTANCED_PROP(float3, _CritPosition)
+#define _CritPosition_arr Shader_OreNew
+		UNITY_INSTANCING_BUFFER_END(Shader_OreNew)
+
+
+		float2 voronoihash1( float2 p )
+		{
+			
+			p = float2( dot( p, float2( 127.1, 311.7 ) ), dot( p, float2( 269.5, 183.3 ) ) );
+			return frac( sin( p ) *43758.5453);
+		}
+
+
+		float voronoi1( float2 v, float time, inout float2 id, inout float2 mr, float smoothness, inout float2 smoothId )
+		{
+			float2 n = floor( v );
+			float2 f = frac( v );
+			float F1 = 8.0;
+			float F2 = 8.0; float2 mg = 0;
+			for ( int j = -1; j <= 1; j++ )
+			{
+				for ( int i = -1; i <= 1; i++ )
+			 	{
+			 		float2 g = float2( i, j );
+			 		float2 o = voronoihash1( n + g );
+					o = ( sin( time + o * 6.2831 ) * 0.5 + 0.5 ); float2 r = f - g - o;
+					float d = 0.5 * dot( r, r );
+			 		if( d<F1 ) {
+			 			F2 = F1;
+			 			F1 = d; mg = g; mr = r; id = o;
+			 		} else if( d<F2 ) {
+			 			F2 = d;
+			
+			 		}
+			 	}
+			}
+			
+F1 = 8.0;
+for ( int j = -2; j <= 2; j++ )
+{
+for ( int i = -2; i <= 2; i++ )
+{
+float2 g = mg + float2( i, j );
+float2 o = voronoihash1( n + g );
+		o = ( sin( time + o * 6.2831 ) * 0.5 + 0.5 ); float2 r = f - g - o;
+float d = dot( 0.5 * ( r + mr ), normalize( r - mr ) );
+F1 = min( F1, d );
+}
+}
+return F1;
+		}
+
+
+		void vertexDataFunc( inout appdata_full v, out Input o )
+		{
+			UNITY_INITIALIZE_OUTPUT( Input, o );
+			float3 objToWorld53 = mul( unity_ObjectToWorld, float4( float3( 0,0,0 ), 1 ) ).xyz;
+			float dotResult4_g5 = dot( objToWorld53.xy , float2( 12.9898,78.233 ) );
+			float lerpResult10_g5 = lerp( 0.0 , 10.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
+			float temp_output_24_0 = lerpResult10_g5;
+			float time1 = temp_output_24_0;
+			float2 voronoiSmoothId1 = 0;
+			float2 coords1 = v.texcoord.xy * 5.0;
+			float2 id1 = 0;
+			float2 uv1 = 0;
+			float voroi1 = voronoi1( coords1, time1, id1, uv1, 0, voronoiSmoothId1 );
+			float temp_output_5_0 = ( 1.0 - voroi1 );
+			float temp_output_45_0 = (0.0 + (temp_output_5_0 - 0.9) * (1.0 - 0.0) / (1.0 - 0.9));
+			float3 ase_vertex3Pos = v.vertex.xyz;
+			float3 normalizeResult35 = normalize( ase_vertex3Pos );
+			float3 temp_output_87_0 = ( normalizeResult35 * float3( 1,1,1 ) );
+			float3 _CrackPosition0_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition0_arr, _CrackPosition0);
+			float3 normalizeResult82 = normalize( _CrackPosition0_Instance );
+			float dotResult84 = dot( temp_output_87_0 , normalizeResult82 );
+			float clampResult99 = clamp( (0.0 + (dotResult84 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
+			float3 _CrackPosition1_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition1_arr, _CrackPosition1);
+			float3 normalizeResult93 = normalize( _CrackPosition1_Instance );
+			float dotResult91 = dot( temp_output_87_0 , normalizeResult93 );
+			float clampResult100 = clamp( (0.0 + (dotResult91 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
+			float3 _CrackPosition2_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition2_arr, _CrackPosition2);
+			float3 normalizeResult102 = normalize( _CrackPosition2_Instance );
+			float dotResult106 = dot( temp_output_87_0 , normalizeResult102 );
+			float clampResult105 = clamp( (0.0 + (dotResult106 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
+			float clampResult97 = clamp( ( clampResult99 + clampResult100 + clampResult105 ) , 0.0 , 3.0 );
+			float clampResult110 = clamp( ( temp_output_45_0 * clampResult97 ) , 0.0 , 1.0 );
+			float3 ase_vertexNormal = v.normal.xyz;
+			v.vertex.xyz += ( clampResult110 * _Float2 * ase_vertexNormal );
+			v.vertex.w = 1;
+		}
+
+		void surf( Input i , inout SurfaceOutputStandard o )
+		{
+			float4 blendOpSrc8 = _Albedo;
+			float4 blendOpDest8 = _CrackLightness;
+			float4 blendOpSrc3 = _Albedo;
+			float4 blendOpDest3 = ( saturate( min( blendOpSrc8 , blendOpDest8 ) ));
+			float3 objToWorld53 = mul( unity_ObjectToWorld, float4( float3( 0,0,0 ), 1 ) ).xyz;
+			float dotResult4_g5 = dot( objToWorld53.xy , float2( 12.9898,78.233 ) );
+			float lerpResult10_g5 = lerp( 0.0 , 10.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
+			float temp_output_24_0 = lerpResult10_g5;
+			float time1 = temp_output_24_0;
+			float2 voronoiSmoothId1 = 0;
+			float2 coords1 = i.uv_texcoord * 5.0;
+			float2 id1 = 0;
+			float2 uv1 = 0;
+			float voroi1 = voronoi1( coords1, time1, id1, uv1, 0, voronoiSmoothId1 );
+			float temp_output_5_0 = ( 1.0 - voroi1 );
+			float clampResult6 = clamp( temp_output_5_0 , 0.0 , 1.0 );
+			float4 lerpBlendMode3 = lerp(blendOpDest3,( blendOpSrc3 * blendOpDest3 ),clampResult6);
+			float div12=256.0/float(2);
+			float4 posterize12 = ( floor( ( saturate( lerpBlendMode3 )) * div12 ) / div12 );
+			float4 color76 = IsGammaSpace() ? float4(0.1981132,0.1132669,0.06448024,1) : float4(0.03251993,0.01220649,0.005366667,1);
+			float4 blendOpSrc28 = posterize12;
+			float4 blendOpDest28 = color76;
+			float3 ase_vertex3Pos = mul( unity_WorldToObject, float4( i.worldPos , 1 ) );
+			float3 normalizeResult68 = normalize( abs( ase_vertex3Pos ) );
+			float dotResult69 = dot( normalizeResult68 , float3( 0,1,0 ) );
+			float4 lerpBlendMode28 = lerp(blendOpDest28,	max( blendOpSrc28, blendOpDest28 ),( dotResult69 * dotResult69 ));
+			float temp_output_45_0 = (0.0 + (temp_output_5_0 - 0.9) * (1.0 - 0.0) / (1.0 - 0.9));
+			float3 normalizeResult35 = normalize( ase_vertex3Pos );
+			float3 temp_output_87_0 = ( normalizeResult35 * float3( 1,1,1 ) );
+			float3 _CrackPosition0_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition0_arr, _CrackPosition0);
+			float3 normalizeResult82 = normalize( _CrackPosition0_Instance );
+			float dotResult84 = dot( temp_output_87_0 , normalizeResult82 );
+			float clampResult99 = clamp( (0.0 + (dotResult84 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
+			float3 _CrackPosition1_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition1_arr, _CrackPosition1);
+			float3 normalizeResult93 = normalize( _CrackPosition1_Instance );
+			float dotResult91 = dot( temp_output_87_0 , normalizeResult93 );
+			float clampResult100 = clamp( (0.0 + (dotResult91 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
+			float3 _CrackPosition2_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition2_arr, _CrackPosition2);
+			float3 normalizeResult102 = normalize( _CrackPosition2_Instance );
+			float dotResult106 = dot( temp_output_87_0 , normalizeResult102 );
+			float clampResult105 = clamp( (0.0 + (dotResult106 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
+			float clampResult97 = clamp( ( clampResult99 + clampResult100 + clampResult105 ) , 0.0 , 3.0 );
+			float clampResult110 = clamp( ( temp_output_45_0 * clampResult97 ) , 0.0 , 1.0 );
+			o.Albedo = ( ( saturate( lerpBlendMode28 )) * ( 1.0 - clampResult110 ) ).rgb;
+			float4 color43 = IsGammaSpace() ? float4(0.936,0.8744736,0.013104,1) : float4(0.8605397,0.7378414,0.001014241,1);
+			float smoothstepResult55 = smoothstep( 0.9 , 1.0 , temp_output_45_0);
+			float3 _CritPosition_Instance = UNITY_ACCESS_INSTANCED_PROP(_CritPosition_arr, _CritPosition);
+			float3 normalizeResult26 = normalize( _CritPosition_Instance );
+			float dotResult16 = dot( normalizeResult35 , normalizeResult26 );
+			float clampResult52 = clamp( ( smoothstepResult55 * (0.0 + (dotResult16 - 0.95) * (1.0 - 0.0) / (1.0 - 0.95)) ) , 0.0 , 1.0 );
+			float4 temp_cast_2 = (clampResult52).xxxx;
+			float4 blendOpSrc42 = color43;
+			float4 blendOpDest42 = temp_cast_2;
+			o.Emission = ( saturate( ( blendOpSrc42 * blendOpDest42 ) )).rgb;
+			o.Alpha = 1;
+		}
+
+		ENDCG
+	}
+	Fallback "Diffuse"
+	CustomEditor "ASEMaterialInspector"
+}
+/*ASEBEGIN
+Version=18935
+1100;220;1927;1104;2058.025;-568.2964;1;True;True
+Node;AmplifyShaderEditor.CommentaryNode;66;-1590.128,325.1008;Inherit;False;1965.974;811.125;Comment;6;42;43;52;46;65;64;Critical cracks;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;64;-1540.128,702.3971;Inherit;False;958.6241;400.45;Mask towards "Crit Position";6;31;16;35;26;25;36;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;128;-1979.118,1283;Inherit;False;1991.234;1102.633;Comment;10;97;94;98;87;146;145;144;101;79;89;Mask Crack Positions;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;101;-1553.33,2057.073;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;79;-1546.36,1448.83;Inherit;False;1062.152;287.2551;Mask towards "Crack Position 0";5;99;85;82;80;84;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.PosVertexDataNode;31;-1490.128,752.3972;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;6;0;Create;True;0;0;0;True;0;False;0,0,0;-0.6,0.2,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1242.101;710.6329;Comment;8;1;6;5;62;137;138;139;140;Voronoi;1,1,1,1;0;0
+Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;5;0;Create;True;0;0;0;True;0;False;0,0,0;0.3,0.7,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;4;0;Create;True;0;0;0;True;0;False;0,0,0;0,1,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.NormalizeNode;35;-1289.127,821.7971;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world position;2;53;24;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1339.392,1333;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;82;-1307.487,1570.18;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.DotProductOpNode;106;-1144.822,2110.755;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;8;28;12;8;2;9;3;71;129;Base Color;1,1,1,1;0;0
+Node;AmplifyShaderEditor.TransformPositionNode;53;-2162.797,-361.0663;Inherit;False;Object;World;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-761.7249;Inherit;False;1155.794;301.5989;Darken edges;6;73;69;68;72;67;76;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;10;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;85;-919.8392,1500.682;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Constant;_VoronoiScale;Voronoi Scale;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.PosVertexDataNode;67;-492.7229,-710.407;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ClampOpNode;99;-641.5961,1504.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
+Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;100;-649.5961,1807.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,1,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.AbsOpNode;72;-314.0877,-707.6897;Inherit;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackLightness;Crack Lightness;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalizeNode;68;-315.7218,-634.0073;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.BlendOpsNode;8;-544.1525,-411.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;55;-836.9797,425.101;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DotProductOpNode;69;-141.9087,-712.7249;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,1,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;36;-871.5046,826.2494;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
+Node;AmplifyShaderEditor.ColorNode;76;342.1132,-697.6896;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;46;-447.7533,611.8972;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
+Node;AmplifyShaderEditor.ClampOpNode;110;261.662,-104.9208;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;73;78.91205,-712.6898;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;-1;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.VoronoiNode;137;-1666.739,-94.47645;Inherit;True;0;0;1;0;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
+Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;15;0;1;32;0;1;FLOAT;0
+Node;AmplifyShaderEditor.OneMinusNode;140;-1475.196,-93.95569;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.TFHCRemapNode;139;-1280.196,-95.95569;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.78;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
+Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.TransformPositionNode;126;2086.822,1073.477;Inherit;False;World;Object;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
+WireConnection;35;0;31;0
+WireConnection;93;0;92;0
+WireConnection;102;0;103;0
+WireConnection;87;0;35;0
+WireConnection;82;0;80;0
+WireConnection;106;0;87;0
+WireConnection;106;1;102;0
+WireConnection;84;0;87;0
+WireConnection;84;1;82;0
+WireConnection;91;0;87;0
+WireConnection;91;1;93;0
+WireConnection;90;0;91;0
+WireConnection;90;1;98;0
+WireConnection;24;1;53;0
+WireConnection;85;0;84;0
+WireConnection;85;1;98;0
+WireConnection;104;0;106;0
+WireConnection;104;1;98;0
+WireConnection;99;0;85;0
+WireConnection;1;1;24;0
+WireConnection;1;2;138;0
+WireConnection;105;0;104;0
+WireConnection;100;0;90;0
+WireConnection;72;0;67;0
+WireConnection;26;0;25;0
+WireConnection;94;0;99;0
+WireConnection;94;1;100;0
+WireConnection;94;2;105;0
+WireConnection;5;0;1;0
+WireConnection;6;0;5;0
+WireConnection;16;0;35;0
+WireConnection;16;1;26;0
+WireConnection;68;0;72;0
+WireConnection;8;0;2;0
+WireConnection;8;1;9;0
+WireConnection;97;0;94;0
+WireConnection;45;0;5;0
+WireConnection;55;0;45;0
+WireConnection;69;0;68;0
+WireConnection;36;0;16;0
+WireConnection;107;0;45;0
+WireConnection;107;1;97;0
+WireConnection;3;0;2;0
+WireConnection;3;1;8;0
+WireConnection;3;2;6;0
+WireConnection;46;0;55;0
+WireConnection;46;1;36;0
+WireConnection;12;1;3;0
+WireConnection;110;0;107;0
+WireConnection;73;0;69;0
+WireConnection;73;1;69;0
+WireConnection;108;0;110;0
+WireConnection;28;0;12;0
+WireConnection;28;1;76;0
+WireConnection;28;2;73;0
+WireConnection;52;0;46;0
+WireConnection;141;0;142;0
+WireConnection;141;1;136;0
+WireConnection;120;0;118;0
+WireConnection;113;0;110;0
+WireConnection;113;1;114;0
+WireConnection;113;2;112;0
+WireConnection;42;0;43;0
+WireConnection;42;1;52;0
+WireConnection;137;1;24;0
+WireConnection;137;2;138;0
+WireConnection;119;0;120;0
+WireConnection;121;0;120;1
+WireConnection;140;0;137;0
+WireConnection;118;0;1;1
+WireConnection;118;1;97;0
+WireConnection;54;0;115;0
+WireConnection;54;1;116;0
+WireConnection;54;2;117;0
+WireConnection;139;0;140;0
+WireConnection;122;0;141;0
+WireConnection;122;1;114;0
+WireConnection;122;2;112;0
+WireConnection;136;0;119;0
+WireConnection;135;1;118;0
+WireConnection;142;0;1;0
+WireConnection;109;0;28;0
+WireConnection;109;1;108;0
+WireConnection;126;0;125;0
+WireConnection;0;0;109;0
+WireConnection;0;2;42;0
+WireConnection;0;11;113;0
+ASEEND*/
+//CHKSM=0D8DD9C3E894F5A813699F962FEF570DE8D8B4F5

--- a/Assets/Entities/Ore/Shader_OreNew.shader
+++ b/Assets/Entities/Ore/Shader_OreNew.shader
@@ -8,12 +8,13 @@ Shader "Shader_OreNew"
 	{
 		_Albedo("Albedo", Color) = (0.5566038,0.4088009,0.2599235,1)
 		_CrackAlbedo("Crack Albedo", Color) = (1,1,1,1)
-		_Float2("Float 2", Float) = -1
 		_CritPosition("Crit Position", Vector) = (0,0,0,0)
 		_VoronoiScale("Voronoi Scale", Float) = 5
 		_CrackPosition0("Crack Position 0", Vector) = (0,0,0,0)
 		_CrackPosition1("Crack Position 1", Vector) = (0,0,0,0)
 		_CrackPosition2("Crack Position 2", Vector) = (0,0,0,0)
+		_EmissionStrength("EmissionStrength", Range( 0 , 100)) = 9
+		_CritCracksSpread("CritCracksSpread", Range( 0 , 1)) = 0.05
 		[HideInInspector] _texcoord( "", 2D ) = "white" {}
 		[HideInInspector] __dirty( "", Int ) = 1
 	}
@@ -24,19 +25,20 @@ Shader "Shader_OreNew"
 		Cull Back
 		CGPROGRAM
 		#include "UnityShaderVariables.cginc"
-		#pragma target 4.6
+		#pragma target 3.0
 		#pragma multi_compile_instancing
-		#pragma surface surf Standard keepalpha addshadow fullforwardshadows vertex:vertexDataFunc 
+		#pragma surface surf Standard keepalpha addshadow fullforwardshadows 
 		struct Input
 		{
 			float2 uv_texcoord;
 			float3 worldPos;
 		};
 
-		uniform float _VoronoiScale;
-		uniform float _Float2;
 		uniform float4 _CrackAlbedo;
 		uniform float4 _Albedo;
+		uniform float _VoronoiScale;
+		uniform float _CritCracksSpread;
+		uniform float _EmissionStrength;
 
 		UNITY_INSTANCING_BUFFER_START(Shader_OreNew)
 			UNITY_DEFINE_INSTANCED_PROP(float3, _CrackPosition0)
@@ -98,41 +100,37 @@ return F1;
 		}
 
 
-		void vertexDataFunc( inout appdata_full v, out Input o )
+		float3 mod2D289( float3 x ) { return x - floor( x * ( 1.0 / 289.0 ) ) * 289.0; }
+
+		float2 mod2D289( float2 x ) { return x - floor( x * ( 1.0 / 289.0 ) ) * 289.0; }
+
+		float3 permute( float3 x ) { return mod2D289( ( ( x * 34.0 ) + 1.0 ) * x ); }
+
+		float snoise( float2 v )
 		{
-			UNITY_INITIALIZE_OUTPUT( Input, o );
-			float4 transform176 = mul(unity_ObjectToWorld,float4( 0,1,0,0 ));
-			float dotResult4_g5 = dot( transform176.xy , float2( 12.9898,78.233 ) );
-			float lerpResult10_g5 = lerp( 0.0 , 20.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
-			float time1 = lerpResult10_g5;
-			float2 voronoiSmoothId1 = 0;
-			float2 coords1 = v.texcoord.xy * _VoronoiScale;
-			float2 id1 = 0;
-			float2 uv1 = 0;
-			float voroi1 = voronoi1( coords1, time1, id1, uv1, 0, voronoiSmoothId1 );
-			float temp_output_5_0 = ( 1.0 - voroi1 );
-			float temp_output_45_0 = (0.0 + (temp_output_5_0 - 0.9) * (1.0 - 0.0) / (1.0 - 0.9));
-			float3 ase_vertex3Pos = v.vertex.xyz;
-			float3 normalizeResult35 = normalize( ase_vertex3Pos );
-			float3 temp_output_87_0 = ( normalizeResult35 * float3( 1,1,1 ) );
-			float3 _CrackPosition0_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition0_arr, _CrackPosition0);
-			float3 normalizeResult82 = normalize( _CrackPosition0_Instance );
-			float dotResult84 = dot( temp_output_87_0 , normalizeResult82 );
-			float clampResult99 = clamp( (0.0 + (dotResult84 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
-			float3 _CrackPosition1_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition1_arr, _CrackPosition1);
-			float3 normalizeResult93 = normalize( _CrackPosition1_Instance );
-			float dotResult91 = dot( temp_output_87_0 , normalizeResult93 );
-			float clampResult100 = clamp( (0.0 + (dotResult91 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
-			float3 _CrackPosition2_Instance = UNITY_ACCESS_INSTANCED_PROP(_CrackPosition2_arr, _CrackPosition2);
-			float3 normalizeResult102 = normalize( _CrackPosition2_Instance );
-			float dotResult106 = dot( temp_output_87_0 , normalizeResult102 );
-			float clampResult105 = clamp( (0.0 + (dotResult106 - 0.75) * (1.0 - 0.0) / (1.0 - 0.75)) , 0.0 , 1.0 );
-			float clampResult97 = clamp( ( clampResult99 + clampResult100 + clampResult105 ) , 0.0 , 3.0 );
-			float clampResult110 = clamp( ( temp_output_45_0 * clampResult97 ) , 0.0 , 1.0 );
-			float3 ase_vertexNormal = v.normal.xyz;
-			v.vertex.xyz += ( clampResult110 * _Float2 * ase_vertexNormal );
-			v.vertex.w = 1;
+			const float4 C = float4( 0.211324865405187, 0.366025403784439, -0.577350269189626, 0.024390243902439 );
+			float2 i = floor( v + dot( v, C.yy ) );
+			float2 x0 = v - i + dot( i, C.xx );
+			float2 i1;
+			i1 = ( x0.x > x0.y ) ? float2( 1.0, 0.0 ) : float2( 0.0, 1.0 );
+			float4 x12 = x0.xyxy + C.xxzz;
+			x12.xy -= i1;
+			i = mod2D289( i );
+			float3 p = permute( permute( i.y + float3( 0.0, i1.y, 1.0 ) ) + i.x + float3( 0.0, i1.x, 1.0 ) );
+			float3 m = max( 0.5 - float3( dot( x0, x0 ), dot( x12.xy, x12.xy ), dot( x12.zw, x12.zw ) ), 0.0 );
+			m = m * m;
+			m = m * m;
+			float3 x = 2.0 * frac( p * C.www ) - 1.0;
+			float3 h = abs( x ) - 0.5;
+			float3 ox = floor( x + 0.5 );
+			float3 a0 = x - ox;
+			m *= 1.79284291400159 - 0.85373472095314 * ( a0 * a0 + h * h );
+			float3 g;
+			g.x = a0.x * x0.x + h.x * x0.y;
+			g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+			return 130.0 * dot( m, g );
 		}
+
 
 		void surf( Input i , inout SurfaceOutputStandard o )
 		{
@@ -181,11 +179,16 @@ return F1;
 			float3 _CritPosition_Instance = UNITY_ACCESS_INSTANCED_PROP(_CritPosition_arr, _CritPosition);
 			float3 normalizeResult26 = normalize( _CritPosition_Instance );
 			float dotResult16 = dot( normalizeResult35 , normalizeResult26 );
-			float clampResult52 = clamp( ( smoothstepResult55 * (0.0 + (dotResult16 - 0.95) * (1.0 - 0.0) / (1.0 - 0.95)) ) , 0.0 , 1.0 );
-			float4 temp_cast_2 = (clampResult52).xxxx;
+			float clampResult52 = clamp( ( smoothstepResult55 * (0.0 + (dotResult16 - ( 1.0 - _CritCracksSpread )) * (1.0 - 0.0) / (1.0 - ( 1.0 - _CritCracksSpread ))) ) , 0.0 , 1.0 );
+			float mulTime196 = _Time.y * 0.01;
+			float4 appendResult198 = (float4(mulTime196 , 0.0 , 0.0 , 0.0));
+			float2 uv_TexCoord195 = i.uv_texcoord + appendResult198.xy;
+			float simplePerlin2D192 = snoise( uv_TexCoord195*30.0 );
+			simplePerlin2D192 = simplePerlin2D192*0.5 + 0.5;
+			float4 temp_cast_3 = (( clampResult52 - (0.0 + (simplePerlin2D192 - 0.0) * (0.3 - 0.0) / (1.0 - 0.0)) )).xxxx;
 			float4 blendOpSrc42 = color43;
-			float4 blendOpDest42 = temp_cast_2;
-			o.Emission = ( saturate( ( blendOpSrc42 * blendOpDest42 ) )).rgb;
+			float4 blendOpDest42 = temp_cast_3;
+			o.Emission = ( ( saturate( ( blendOpSrc42 * blendOpDest42 ) )) * _EmissionStrength ).rgb;
 			o.Alpha = 1;
 		}
 
@@ -196,173 +199,194 @@ return F1;
 }
 /*ASEBEGIN
 Version=18935
-841;247;1729;955;2824.569;592.1526;1;True;True
-Node;AmplifyShaderEditor.CommentaryNode;66;-1590.128,325.1008;Inherit;False;1965.974;811.125;Comment;6;42;43;52;46;65;64;Critical cracks;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;64;-1540.128,702.3971;Inherit;False;958.6241;400.45;Mask towards "Crit Position";6;31;16;35;26;25;36;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;128;-1979.118,1283;Inherit;False;1991.234;1102.633;Comment;10;97;94;98;87;146;145;144;101;79;89;Mask Crack Positions;1,1,1,1;0;0
-Node;AmplifyShaderEditor.PosVertexDataNode;31;-1490.128,752.3972;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;79;-1546.36,1448.83;Inherit;False;1062.152;287.2551;Mask towards "Crack Position 0";5;99;85;82;80;84;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;101;-1553.33,2057.073;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
+537;343;1729;955;2515.09;-625.5458;1;True;True
+Node;AmplifyShaderEditor.CommentaryNode;66;-2288.18,362.4552;Inherit;False;2190.409;1108.87;Comment;15;197;196;191;42;179;43;194;52;193;46;192;195;65;64;198;Critical cracks;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;64;-2255.463,739.7515;Inherit;False;1175.899;415.2642;Mask towards "Crit Position";9;36;16;26;25;35;31;180;200;201;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;128;-1990.228,1680.734;Inherit;False;1991.234;1102.633;Comment;10;97;94;98;87;146;145;144;101;79;89;Mask Crack Positions;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1251.027;757.0484;Comment;5;6;5;1;138;62;Voronoi;1,1,1,1;0;0
-Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;7;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.NormalizeNode;35;-1289.127,821.7971;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1339.392,1333;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;82;-1307.487,1570.18;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;101;-1564.44,2454.807;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;79;-1557.47,1846.564;Inherit;False;1062.152;287.2551;Mask towards "Crack Position 0";5;99;85;82;80;84;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world "up-axis" direction;2;24;176;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.DotProductOpNode;106;-1144.822,2110.755;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.PosVertexDataNode;31;-1988.188,789.7516;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.CommentaryNode;89;-1563.436,2152.826;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.NormalizeNode;35;-1787.187,859.1516;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.Vector3Node;92;-1525.146,2211.057;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.ObjectToWorldTransfNode;176;-2149.569,-357.1526;Inherit;False;1;0;FLOAT4;0,1,0,0;False;5;FLOAT4;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;20;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;85;-919.8392,1500.682;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.Vector3Node;80;-1522.976,1904.794;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;103;-1526.15,2513.037;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;7;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Property;_VoronoiScale;Voronoi Scale;4;0;Create;True;0;0;0;False;0;False;5;7;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;20;False;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalizeNode;82;-1318.597,1967.914;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1350.502,1730.734;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;102;-1321.771,2576.156;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;93;-1320.767,2274.176;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.DotProductOpNode;84;-1152.758,1900.246;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;98;-1161.613,1741.332;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
-Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.ClampOpNode;99;-641.5961,1504.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;100;-649.5961,1807.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TextureCoordinatesNode;148;-523.285,-746.3354;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.RangedFloatNode;197;-1701.298,1189.604;Inherit;False;Constant;_Float6;Float 6;9;0;Create;True;0;0;0;False;0;False;0.01;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.DotProductOpNode;91;-1154.928,2206.509;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.Vector3Node;25;-1981.713,952.2017;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.DotProductOpNode;106;-1155.932,2508.489;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.SimpleTimeNode;196;-1545.569,1191.586;Inherit;False;1;0;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;90;-933.1182,2204.678;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;200;-1678.036,788.5909;Inherit;False;Property;_CritCracksSpread;CritCracksSpread;9;0;Create;True;0;0;0;False;0;False;0.05;0.03;0;1;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;104;-934.1225,2506.658;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;65;-1696.697,412.4552;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.TFHCRemapNode;85;-930.949,1898.416;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalizeNode;26;-1788.213,945.1013;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.OneMinusNode;201;-1406.036,789.5909;Inherit;False;1;0;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;198;-1342.616,1175.022;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.DotProductOpNode;16;-1610.374,863.4337;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;105;-661.7101,2507.191;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;100;-660.7059,2205.212;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;45;-1646.697,463.0281;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;99;-652.7059,1902.212;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;7;28;12;2;9;3;71;129;Base Color;1,1,1,1;0;0
-Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TextureCoordinatesNode;195;-1186.077,1164.316;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleAddOpNode;94;-389.1177,2045.622;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;36;-1369.564,863.6038;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TextureCoordinatesNode;148;-523.285,-746.3354;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SmoothstepOpNode;55;-1335.039,462.4554;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;97;-169.9938,2046.247;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;46;-1040.937,441.7067;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.NoiseGeneratorNode;192;-1050.397,916.6709;Inherit;True;Simplex2D;True;False;2;0;FLOAT2;0,0;False;1;FLOAT;30;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.794,0.7201173,0.642346,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0.595,0.5367935,0.4656522,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-802.0814;Inherit;False;1155.794;361.0718;Darken edges;1;76;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.ClampOpNode;52;-1050.001,680.7764;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;193;-809.8801,923.6071;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;0.3;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;55;-836.9797,425.101;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.TFHCRemapNode;36;-871.5046,826.2494;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;153;191.1495,-739.3545;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;46;-447.7533,611.8972;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;110;261.662,-104.9208;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
+Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
+Node;AmplifyShaderEditor.ColorNode;43;-537.941,450.1918;Inherit;False;Constant;_EmissionColor;EmissionColor;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.ClampOpNode;153;191.1495,-739.3545;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ColorNode;76;342.1132,-738.046;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.SimpleSubtractOpNode;194;-781.1864,752.6968;Inherit;False;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
-Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.RangedFloatNode;179;-574.5415,883.9559;Inherit;False;Property;_EmissionStrength;EmissionStrength;8;0;Create;True;0;0;0;False;0;False;9;10;0;100;0;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;42;-558.8153,643.3081;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
+Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DynamicAppendNode;180;-2156.581,962.3496;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;0.4;False;2;FLOAT;-1;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.DynamicAppendNode;145;-1718.565,2208.958;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
 Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;0;0;0;0;1;FLOAT;0
 Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
+Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;191;-267.4262,787.5975;Inherit;False;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
+Node;AmplifyShaderEditor.DynamicAppendNode;144;-1717.565,1947.958;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.DynamicAppendNode;146;-1713.565,2529.957;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.TransformPositionNode;126;2086.822,1073.477;Inherit;False;World;Object;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
-Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
-Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.StandardSurfaceOutputNode;190;2313.181,345.8943;Float;False;True;-1;2;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
 WireConnection;35;0;31;0
-WireConnection;87;0;35;0
-WireConnection;93;0;92;0
+WireConnection;24;1;176;0
 WireConnection;82;0;80;0
+WireConnection;87;0;35;0
 WireConnection;102;0;103;0
-WireConnection;106;0;87;0
-WireConnection;106;1;102;0
+WireConnection;93;0;92;0
 WireConnection;84;0;87;0
 WireConnection;84;1;82;0
-WireConnection;91;0;87;0
-WireConnection;91;1;93;0
-WireConnection;24;1;176;0
-WireConnection;85;0;84;0
-WireConnection;85;1;98;0
-WireConnection;104;0;106;0
-WireConnection;104;1;98;0
-WireConnection;90;0;91;0
-WireConnection;90;1;98;0
 WireConnection;1;1;24;0
 WireConnection;1;2;138;0
-WireConnection;99;0;85;0
-WireConnection;100;0;90;0
-WireConnection;105;0;104;0
+WireConnection;91;0;87;0
+WireConnection;91;1;93;0
+WireConnection;106;0;87;0
+WireConnection;106;1;102;0
 WireConnection;5;0;1;0
+WireConnection;196;0;197;0
+WireConnection;90;0;91;0
+WireConnection;90;1;98;0
+WireConnection;104;0;106;0
+WireConnection;104;1;98;0
+WireConnection;85;0;84;0
+WireConnection;85;1;98;0
 WireConnection;26;0;25;0
+WireConnection;201;0;200;0
+WireConnection;198;0;196;0
+WireConnection;16;0;35;0
+WireConnection;16;1;26;0
+WireConnection;105;0;104;0
+WireConnection;100;0;90;0
+WireConnection;45;0;5;0
+WireConnection;99;0;85;0
+WireConnection;195;1;198;0
 WireConnection;94;0;99;0
 WireConnection;94;1;100;0
 WireConnection;94;2;105;0
-WireConnection;97;0;94;0
-WireConnection;16;0;35;0
-WireConnection;16;1;26;0
+WireConnection;36;0;16;0
+WireConnection;36;1;201;0
+WireConnection;55;0;45;0
 WireConnection;150;0;148;0
-WireConnection;45;0;5;0
+WireConnection;97;0;94;0
+WireConnection;46;0;55;0
+WireConnection;46;1;36;0
+WireConnection;192;0;195;0
 WireConnection;6;0;5;0
-WireConnection;152;0;150;0
+WireConnection;52;0;46;0
+WireConnection;193;0;192;0
 WireConnection;107;0;45;0
 WireConnection;107;1;97;0
-WireConnection;55;0;45;0
 WireConnection;3;0;9;0
 WireConnection;3;1;2;0
 WireConnection;3;2;6;0
-WireConnection;36;0;16;0
-WireConnection;153;0;152;0
-WireConnection;12;1;3;0
-WireConnection;46;0;55;0
-WireConnection;46;1;36;0
+WireConnection;152;0;150;0
 WireConnection;110;0;107;0
+WireConnection;12;1;3;0
+WireConnection;153;0;152;0
+WireConnection;194;0;52;0
+WireConnection;194;1;193;0
 WireConnection;28;0;12;0
 WireConnection;28;1;76;0
 WireConnection;28;2;153;0
 WireConnection;108;0;110;0
-WireConnection;52;0;46;0
-WireConnection;113;0;110;0
-WireConnection;113;1;114;0
-WireConnection;113;2;112;0
-WireConnection;135;1;118;0
-WireConnection;109;0;28;0
-WireConnection;109;1;108;0
-WireConnection;118;0;1;1
-WireConnection;118;1;97;0
-WireConnection;122;0;141;0
-WireConnection;122;1;114;0
-WireConnection;122;2;112;0
-WireConnection;141;0;142;0
-WireConnection;141;1;136;0
-WireConnection;120;0;118;0
-WireConnection;142;0;1;0
+WireConnection;42;0;43;0
+WireConnection;42;1;194;0
 WireConnection;136;0;119;0
 WireConnection;54;0;115;0
 WireConnection;54;1;116;0
 WireConnection;54;2;117;0
-WireConnection;119;0;120;0
 WireConnection;121;0;120;1
+WireConnection;119;0;120;0
+WireConnection;141;0;142;0
+WireConnection;141;1;136;0
+WireConnection;122;0;141;0
+WireConnection;122;1;114;0
+WireConnection;122;2;112;0
+WireConnection;142;0;1;0
+WireConnection;120;0;118;0
+WireConnection;135;1;118;0
+WireConnection;191;0;42;0
+WireConnection;191;1;179;0
+WireConnection;109;0;28;0
+WireConnection;109;1;108;0
+WireConnection;113;0;110;0
+WireConnection;113;1;114;0
+WireConnection;113;2;112;0
 WireConnection;126;0;125;0
-WireConnection;42;0;43;0
-WireConnection;42;1;52;0
-WireConnection;0;0;109;0
-WireConnection;0;2;42;0
-WireConnection;0;11;113;0
+WireConnection;118;0;1;1
+WireConnection;118;1;97;0
+WireConnection;190;0;109;0
+WireConnection;190;2;191;0
 ASEEND*/
-//CHKSM=D0299198AB4D202F46EA60B91B67B23BE8765D92
+//CHKSM=B0744B55B138B6FB1683172EED4CAD6539799931

--- a/Assets/Entities/Ore/Shader_OreNew.shader
+++ b/Assets/Entities/Ore/Shader_OreNew.shader
@@ -101,7 +101,8 @@ return F1;
 		void vertexDataFunc( inout appdata_full v, out Input o )
 		{
 			UNITY_INITIALIZE_OUTPUT( Input, o );
-			float dotResult4_g5 = dot( float2( 0,0 ) , float2( 12.9898,78.233 ) );
+			float4 transform176 = mul(unity_ObjectToWorld,float4( 0,1,0,0 ));
+			float dotResult4_g5 = dot( transform176.xy , float2( 12.9898,78.233 ) );
 			float lerpResult10_g5 = lerp( 0.0 , 20.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
 			float time1 = lerpResult10_g5;
 			float2 voronoiSmoothId1 = 0;
@@ -137,7 +138,8 @@ return F1;
 		{
 			float4 blendOpSrc3 = _CrackAlbedo;
 			float4 blendOpDest3 = _Albedo;
-			float dotResult4_g5 = dot( float2( 0,0 ) , float2( 12.9898,78.233 ) );
+			float4 transform176 = mul(unity_ObjectToWorld,float4( 0,1,0,0 ));
+			float dotResult4_g5 = dot( transform176.xy , float2( 12.9898,78.233 ) );
 			float lerpResult10_g5 = lerp( 0.0 , 20.0 , frac( ( sin( dotResult4_g5 ) * 43758.55 ) ));
 			float time1 = lerpResult10_g5;
 			float2 voronoiSmoothId1 = 0;
@@ -180,9 +182,9 @@ return F1;
 			float3 normalizeResult26 = normalize( _CritPosition_Instance );
 			float dotResult16 = dot( normalizeResult35 , normalizeResult26 );
 			float clampResult52 = clamp( ( smoothstepResult55 * (0.0 + (dotResult16 - 0.95) * (1.0 - 0.0) / (1.0 - 0.95)) ) , 0.0 , 1.0 );
-			float4 temp_cast_1 = (clampResult52).xxxx;
+			float4 temp_cast_2 = (clampResult52).xxxx;
 			float4 blendOpSrc42 = color43;
-			float4 blendOpDest42 = temp_cast_1;
+			float4 blendOpDest42 = temp_cast_2;
 			o.Emission = ( saturate( ( blendOpSrc42 * blendOpDest42 ) )).rgb;
 			o.Alpha = 1;
 		}
@@ -194,165 +196,166 @@ return F1;
 }
 /*ASEBEGIN
 Version=18935
-648;249;1729;955;2601.67;795.2008;1;True;True
+841;247;1729;955;2824.569;592.1526;1;True;True
 Node;AmplifyShaderEditor.CommentaryNode;66;-1590.128,325.1008;Inherit;False;1965.974;811.125;Comment;6;42;43;52;46;65;64;Critical cracks;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;64;-1540.128,702.3971;Inherit;False;958.6241;400.45;Mask towards "Crit Position";6;31;16;35;26;25;36;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;128;-1979.118,1283;Inherit;False;1991.234;1102.633;Comment;10;97;94;98;87;146;145;144;101;79;89;Mask Crack Positions;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;79;-1546.36,1448.83;Inherit;False;1062.152;287.2551;Mask towards "Crack Position 0";5;99;85;82;80;84;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.PosVertexDataNode;31;-1490.128,752.3972;Inherit;False;0;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.CommentaryNode;89;-1552.326,1755.092;Inherit;False;1066.948;284.2551;Mask towards "Crack Position 1";5;90;92;93;91;100;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.CommentaryNode;79;-1546.36,1448.83;Inherit;False;1062.152;287.2551;Mask towards "Crack Position 0";5;99;85;82;80;84;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.CommentaryNode;101;-1553.33,2057.073;Inherit;False;1066.948;286.1528;Mask towards "Crack Position 2";5;106;105;104;103;102;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1251.027;757.0484;Comment;5;6;5;1;138;62;Voronoi;1,1,1,1;0;0
 Node;AmplifyShaderEditor.Vector3Node;103;-1515.04,2115.303;Inherit;False;InstancedProperty;_CrackPosition2;Crack Position 2;7;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.Vector3Node;80;-1511.866,1507.06;Inherit;False;InstancedProperty;_CrackPosition0;Crack Position 0;5;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.NormalizeNode;35;-1289.127,821.7971;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.CommentaryNode;63;-2262.797,-461.0663;Inherit;False;1242.101;710.6329;Comment;5;1;6;5;62;138;Voronoi;1,1,1,1;0;0
-Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.Vector3Node;92;-1514.036,1813.323;Inherit;False;InstancedProperty;_CrackPosition1;Crack Position 1;6;0;Create;True;0;0;0;True;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;87;-1339.392,1333;Inherit;False;2;2;0;FLOAT3;0,0,0;False;1;FLOAT3;1,1,1;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.NormalizeNode;93;-1309.657,1876.442;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.NormalizeNode;82;-1307.487,1570.18;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world position;2;53;24;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.NormalizeNode;102;-1310.661,2178.422;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;62;-2212.797,-411.0663;Inherit;False;507.1282;238;Randomize texture by world "up-axis" direction;2;24;176;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.DotProductOpNode;106;-1144.822,2110.755;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Property;_VoronoiScale;Voronoi Scale;4;0;Create;True;0;0;0;False;0;False;5;7;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;98;-1150.503,1343.598;Inherit;False;Constant;_Float1;Float 1;2;0;Create;True;0;0;0;False;0;False;0.75;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.DotProductOpNode;84;-1141.648,1502.512;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.DotProductOpNode;91;-1143.818,1808.775;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ObjectToWorldTransfNode;176;-2149.569,-357.1526;Inherit;False;1;0;FLOAT4;0,1,0,0;False;5;FLOAT4;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.FunctionNode;24;-1910.67,-359.3318;Inherit;False;Random Range;-1;;5;7b754edb8aebbfb4a9ace907af661cfc;0;3;1;FLOAT2;0,0;False;2;FLOAT;0;False;3;FLOAT;20;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;85;-919.8392,1500.682;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;138;-1896.336,-49.86877;Inherit;False;Property;_VoronoiScale;Voronoi Scale;4;0;Create;True;0;0;0;False;0;False;5;7;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;104;-923.0127,2108.924;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCRemapNode;90;-922.0084,1806.944;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
+Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.ClampOpNode;99;-641.5961,1504.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;100;-649.5961,1807.478;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.Vector3Node;25;-1483.653,914.8473;Inherit;False;InstancedProperty;_CritPosition;Crit Position;3;0;Create;True;0;0;0;False;0;False;0,0,0;0,0,0;0;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.VoronoiNode;1;-1665.197,-382.6334;Inherit;True;0;0;1;4;1;False;4;False;False;False;4;0;FLOAT2;0,0;False;1;FLOAT;0;False;2;FLOAT;5;False;3;FLOAT;0;False;3;FLOAT;0;FLOAT2;1;FLOAT2;2
 Node;AmplifyShaderEditor.ClampOpNode;105;-650.6003,2109.457;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;7;28;12;2;9;3;71;129;Base Color;1,1,1,1;0;0
 Node;AmplifyShaderEditor.TextureCoordinatesNode;148;-523.285,-746.3354;Inherit;False;0;-1;2;3;2;SAMPLER2D;;False;0;FLOAT2;1,1;False;1;FLOAT2;0,0;False;5;FLOAT2;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.OneMinusNode;5;-1466.197,-388.6334;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;65;-1198.637,375.1008;Inherit;False;615.6573;304.5728;Sharpen cracks;2;45;55;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.NormalizeNode;26;-1290.153,907.7469;Inherit;False;False;1;0;FLOAT3;0,0,0;False;1;FLOAT3;0
+Node;AmplifyShaderEditor.CommentaryNode;61;-923.7529,-851.9329;Inherit;False;1871.511;1037.927;Comment;7;28;12;2;9;3;71;129;Base Color;1,1,1,1;0;0
+Node;AmplifyShaderEditor.SimpleAddOpNode;94;-378.0079,1647.888;Inherit;True;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.794,0.7201173,0.642346,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.ColorNode;9;-870.1528,-374.332;Inherit;False;Property;_CrackAlbedo;Crack Albedo;1;0;Create;True;0;0;0;False;0;False;1,1,1,1;0.595,0.5367935,0.4656522,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.ClampOpNode;97;-158.8839,1648.513;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;3;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
-Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
 Node;AmplifyShaderEditor.DotProductOpNode;16;-1112.314,826.0793;Inherit;True;2;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;2;-871.1528,-591.3323;Inherit;False;Property;_Albedo;Albedo;0;0;Create;True;0;0;0;False;0;False;0.5566038,0.4088009,0.2599235,1;0.794,0.7201173,0.642346,1;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.DistanceOpNode;150;-297.285,-745.3354;Inherit;True;2;0;FLOAT2;0,0;False;1;FLOAT2;0.5,0.5;False;1;FLOAT;0
+Node;AmplifyShaderEditor.CommentaryNode;129;1.330471,-158.3274;Inherit;False;914.6672;307.4066;Darken cracks in "Crack Positions" Mask;4;109;108;107;110;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.TFHCRemapNode;45;-1148.637,425.6737;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;6;-1266.716,-387.6334;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.TFHCRemapNode;152;-76.28503,-742.3354;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;-1.3;False;4;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.CommentaryNode;71;-542.7219,-802.0814;Inherit;False;1155.794;361.0718;Darken edges;1;76;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;107;51.33055,-106.1982;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.TFHCRemapNode;36;-871.5046,826.2494;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SmoothstepOpNode;55;-836.9797,425.101;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0.9;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BlendOpsNode;3;-196.1527,-408.3319;Inherit;True;Darken;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
+Node;AmplifyShaderEditor.TFHCRemapNode;36;-871.5046,826.2494;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.95;False;2;FLOAT;1;False;3;FLOAT;0;False;4;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.ClampOpNode;153;191.1495,-739.3545;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;46;-447.7533,611.8972;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
 Node;AmplifyShaderEditor.ClampOpNode;110;261.662,-104.9208;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;76;342.1132,-738.046;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.ClampOpNode;153;191.1495,-739.3545;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.CommentaryNode;143;530.7997,926.6227;Inherit;False;1929.92;891.5056;Comment;14;118;120;119;136;121;142;114;141;112;113;126;125;135;122;Vertex Displacement Experiment;1,1,1,1;0;0
-Node;AmplifyShaderEditor.PosterizeNode;12;81.70221,-406.3568;Inherit;True;2;2;1;COLOR;0,0,0,0;False;0;INT;2;False;1;COLOR;0
+Node;AmplifyShaderEditor.ColorNode;76;342.1132,-738.046;Inherit;False;Constant;_Color1;Color 1;2;0;Create;True;0;0;0;False;0;False;0.1981132,0.1132669,0.06448024,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
+Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
+Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.BlendOpsNode;28;372.0377,-405.4874;Inherit;True;Lighten;True;3;0;COLOR;0,0,0,0;False;1;COLOR;0,0,0,0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.NormalVertexDataNode;112;1907.794,1461.582;Inherit;False;0;5;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
 Node;AmplifyShaderEditor.RangedFloatNode;114;1923.953,1356.94;Inherit;False;Property;_Float2;Float 2;2;0;Create;True;0;0;0;False;0;False;-1;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.ColorNode;43;-212.836,418.6025;Inherit;False;Constant;_Color0;Color 0;2;0;Create;True;0;0;0;False;0;False;0.936,0.8744736,0.013104,1;0,0,0,0;True;0;5;COLOR;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4
-Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.CommentaryNode;127;1328.238,-87.299;Inherit;False;617.5722;357.2172;Tesselation;4;115;54;117;116;;1,1,1,1;0;0
 Node;AmplifyShaderEditor.OneMinusNode;108;495.3158,-106.1627;Inherit;True;1;0;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
-Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.ClampOpNode;52;-230.5354,608.8312;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;113;2291.973,1232.172;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
 Node;AmplifyShaderEditor.PosterizeNode;135;1286.738,1134.071;Inherit;True;3;2;1;COLOR;0,0,0,0;False;0;INT;3;False;1;COLOR;0
-Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
-Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
-Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
 Node;AmplifyShaderEditor.DynamicAppendNode;144;-1881.756,1510.719;Inherit;False;FLOAT4;4;0;FLOAT;0;False;1;FLOAT;1;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;109;680.9976,-108.3274;Inherit;True;2;2;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;1;COLOR;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;118;580.7997,1496.767;Inherit;True;2;2;0;FLOAT2;0,0;False;1;FLOAT;1;False;1;FLOAT2;0
+Node;AmplifyShaderEditor.WorldNormalVector;125;1889.394,1074.1;Inherit;False;False;1;0;FLOAT3;0,0,1;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.SimpleMultiplyOpNode;122;2298.72,1419.579;Inherit;False;3;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT3;0,0,0;False;1;FLOAT3;0
 Node;AmplifyShaderEditor.DynamicAppendNode;146;-1877.756,2092.719;Inherit;False;FLOAT4;4;0;FLOAT;-0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.SimpleMultiplyOpNode;141;1680.707,1248.173;Inherit;True;2;2;0;FLOAT;0;False;1;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.BreakToComponentsNode;120;809.7962,1501.129;Inherit;False;FLOAT2;1;0;FLOAT2;0,0;False;16;FLOAT;0;FLOAT;1;FLOAT;2;FLOAT;3;FLOAT;4;FLOAT;5;FLOAT;6;FLOAT;7;FLOAT;8;FLOAT;9;FLOAT;10;FLOAT;11;FLOAT;12;FLOAT;13;FLOAT;14;FLOAT;15
+Node;AmplifyShaderEditor.ClampOpNode;142;1405.632,976.6229;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
+Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
+Node;AmplifyShaderEditor.RangedFloatNode;117;1514.296,153.9183;Inherit;False;Constant;_Float5;Float 5;3;0;Create;True;0;0;0;False;0;False;5;0;0;0;0;1;FLOAT;0
+Node;AmplifyShaderEditor.DistanceBasedTessNode;54;1697.811,24.57692;Inherit;False;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.RangedFloatNode;115;1378.238,-37.29879;Inherit;False;Constant;_Float3;Float 3;3;0;Create;True;0;0;0;False;0;False;32;0;1;32;0;1;FLOAT;0
 Node;AmplifyShaderEditor.RangedFloatNode;116;1515.306,57.15995;Inherit;False;Constant;_Float4;Float 4;3;0;Create;True;0;0;0;False;0;False;0;0;0;0;0;1;FLOAT;0
-Node;AmplifyShaderEditor.TransformPositionNode;53;-2162.797,-361.0663;Inherit;False;Object;World;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
-Node;AmplifyShaderEditor.TFHCCompareWithRange;136;1291.132,1410.036;Inherit;True;5;0;FLOAT;0;False;1;FLOAT;0.86;False;2;FLOAT;1;False;3;FLOAT;1;False;4;FLOAT;0;False;1;FLOAT;0
-Node;AmplifyShaderEditor.SmoothstepOpNode;119;985.7963,1338.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
 Node;AmplifyShaderEditor.SmoothstepOpNode;121;981.7963,1564.129;Inherit;True;3;0;FLOAT;0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;FLOAT;0
-Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.TransformPositionNode;126;2086.822,1073.477;Inherit;False;World;Object;False;Fast;True;1;0;FLOAT3;0,0,0;False;4;FLOAT3;0;FLOAT;1;FLOAT;2;FLOAT;3
+Node;AmplifyShaderEditor.DynamicAppendNode;145;-1882.756,1771.719;Inherit;False;FLOAT4;4;0;FLOAT;0.7;False;1;FLOAT;0.3;False;2;FLOAT;0;False;3;FLOAT;0;False;1;FLOAT4;0
+Node;AmplifyShaderEditor.IntNode;123;-272.597,1164.019;Inherit;False;Constant;_Health;Health;3;0;Create;True;0;0;0;False;0;False;1;0;False;0;1;INT;0
 Node;AmplifyShaderEditor.BlendOpsNode;42;45.89881,523.8005;Inherit;True;Multiply;True;3;0;COLOR;0,0,0,0;False;1;FLOAT;0;False;2;FLOAT;1;False;1;COLOR;0
 Node;AmplifyShaderEditor.StandardSurfaceOutputNode;0;2313.181,345.8943;Float;False;True;-1;6;ASEMaterialInspector;0;0;Standard;Shader_OreNew;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;Back;0;False;-1;0;False;-1;False;0;False;-1;0;False;-1;False;0;Opaque;0.5;True;True;0;False;Opaque;;Geometry;All;18;all;True;True;True;True;0;False;-1;False;0;False;-1;255;False;-1;255;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;-1;False;2;15;10;25;False;0.5;True;0;0;False;-1;0;False;-1;0;0;False;-1;0;False;-1;0;False;-1;0;False;-1;0;False;0;0,0,0,0;VertexOffset;True;False;Cylindrical;False;True;Relative;0;;-1;-1;-1;-1;0;False;0;0;False;-1;-1;0;False;-1;0;0;0;False;0.1;False;-1;0;False;-1;False;16;0;FLOAT3;0,0,0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;0;False;4;FLOAT;0;False;5;FLOAT;0;False;6;FLOAT3;0,0,0;False;7;FLOAT3;0,0,0;False;8;FLOAT;0;False;9;FLOAT;0;False;10;FLOAT;0;False;13;FLOAT3;0,0,0;False;11;FLOAT3;0,0,0;False;12;FLOAT3;0,0,0;False;14;FLOAT4;0,0,0,0;False;15;FLOAT3;0,0,0;False;0
 WireConnection;35;0;31;0
-WireConnection;102;0;103;0
-WireConnection;93;0;92;0
 WireConnection;87;0;35;0
+WireConnection;93;0;92;0
 WireConnection;82;0;80;0
+WireConnection;102;0;103;0
+WireConnection;106;0;87;0
+WireConnection;106;1;102;0
 WireConnection;84;0;87;0
 WireConnection;84;1;82;0
 WireConnection;91;0;87;0
 WireConnection;91;1;93;0
-WireConnection;106;0;87;0
-WireConnection;106;1;102;0
-WireConnection;90;0;91;0
-WireConnection;90;1;98;0
-WireConnection;104;0;106;0
-WireConnection;104;1;98;0
+WireConnection;24;1;176;0
 WireConnection;85;0;84;0
 WireConnection;85;1;98;0
-WireConnection;99;0;85;0
-WireConnection;100;0;90;0
+WireConnection;104;0;106;0
+WireConnection;104;1;98;0
+WireConnection;90;0;91;0
+WireConnection;90;1;98;0
 WireConnection;1;1;24;0
 WireConnection;1;2;138;0
+WireConnection;99;0;85;0
+WireConnection;100;0;90;0
 WireConnection;105;0;104;0
-WireConnection;26;0;25;0
 WireConnection;5;0;1;0
+WireConnection;26;0;25;0
 WireConnection;94;0;99;0
 WireConnection;94;1;100;0
 WireConnection;94;2;105;0
 WireConnection;97;0;94;0
-WireConnection;6;0;5;0
-WireConnection;150;0;148;0
 WireConnection;16;0;35;0
 WireConnection;16;1;26;0
+WireConnection;150;0;148;0
 WireConnection;45;0;5;0
+WireConnection;6;0;5;0
 WireConnection;152;0;150;0
+WireConnection;107;0;45;0
+WireConnection;107;1;97;0
+WireConnection;55;0;45;0
 WireConnection;3;0;9;0
 WireConnection;3;1;2;0
 WireConnection;3;2;6;0
-WireConnection;107;0;45;0
-WireConnection;107;1;97;0
 WireConnection;36;0;16;0
-WireConnection;55;0;45;0
+WireConnection;153;0;152;0
+WireConnection;12;1;3;0
 WireConnection;46;0;55;0
 WireConnection;46;1;36;0
 WireConnection;110;0;107;0
-WireConnection;153;0;152;0
-WireConnection;12;1;3;0
 WireConnection;28;0;12;0
 WireConnection;28;1;76;0
 WireConnection;28;2;153;0
-WireConnection;52;0;46;0
 WireConnection;108;0;110;0
-WireConnection;54;0;115;0
-WireConnection;54;1;116;0
-WireConnection;54;2;117;0
+WireConnection;52;0;46;0
 WireConnection;113;0;110;0
 WireConnection;113;1;114;0
 WireConnection;113;2;112;0
-WireConnection;142;0;1;0
+WireConnection;135;1;118;0
 WireConnection;109;0;28;0
 WireConnection;109;1;108;0
-WireConnection;135;1;118;0
+WireConnection;118;0;1;1
+WireConnection;118;1;97;0
 WireConnection;122;0;141;0
 WireConnection;122;1;114;0
 WireConnection;122;2;112;0
-WireConnection;120;0;118;0
-WireConnection;118;0;1;1
-WireConnection;118;1;97;0
 WireConnection;141;0;142;0
 WireConnection;141;1;136;0
+WireConnection;120;0;118;0
+WireConnection;142;0;1;0
 WireConnection;136;0;119;0
+WireConnection;54;0;115;0
+WireConnection;54;1;116;0
+WireConnection;54;2;117;0
 WireConnection;119;0;120;0
 WireConnection;121;0;120;1
 WireConnection;126;0;125;0
@@ -362,4 +365,4 @@ WireConnection;0;0;109;0
 WireConnection;0;2;42;0
 WireConnection;0;11;113;0
 ASEEND*/
-//CHKSM=7E1BDD11C9BCBBA91C7EAAFF27648526886CB04D
+//CHKSM=D0299198AB4D202F46EA60B91B67B23BE8765D92

--- a/Assets/Entities/Ore/Shader_OreNew.shader.meta
+++ b/Assets/Entities/Ore/Shader_OreNew.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 835721fa6edc42543a9793e37ba98b5a
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CaveV2/SpawnObjects/LevelObjectSpawner.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/LevelObjectSpawner.cs
@@ -258,7 +258,7 @@ namespace BML.Scripts.CaveV2.SpawnObjects
                         spawnAt.rotation = spawnAt.rotation ?? cachedTransform.rotation;
                         
                         // Cancel spawn if did not find surface to spawn
-                        if (spawnAtTagParameters.RequireStableSurface && !hitStableSurface)
+                        if (spawnPoint.RequireStableSurface && !hitStableSurface)
                         {
                             if (_caveGenerator.EnableLogs)
                                 Debug.LogWarning($"Failed to spawn {spawnAtTagParameters.Prefab?.name}. No stable " +

--- a/Assets/Scripts/CaveV2/SpawnObjects/LevelObjectSpawnerParameters.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/LevelObjectSpawnerParameters.cs
@@ -28,7 +28,6 @@ namespace BML.Scripts.CaveV2.SpawnObjects
             public string Tag;
             public GameObject Prefab;
             [FoldoutGroup("Parameters")] public float SpawnPosOffset = 0f;
-            [FoldoutGroup("Parameters")] public bool RequireStableSurface;
             [FoldoutGroup("Parameters")] public bool InstanceAsPrefab;
             [FoldoutGroup("Parameters")] public bool ChooseWithoutReplacement;
             [FoldoutGroup("Parameters")] [Range(0f, 1f)] public float SpawnProbability;

--- a/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
@@ -36,11 +36,14 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         private Vector3 _projectionVector = Vector3.down;
         [SerializeField, ShowIf("@this._projectionBehavior == SpawnPointProjectionBehavior.Randomize")] 
         private Vector2 _projectionDirectionRandomnessRangeDegrees = new Vector2(30, 15);
-        [SerializeField] private float _projectionDistance = 45f;
+        [SerializeField, ShowIf("@this._projectionBehavior != SpawnPointProjectionBehavior.None")]
+        private float _projectionDistance = 45f;
+        [SerializeField, ShowIf("@this._projectionBehavior != SpawnPointProjectionBehavior.None")]
+        public bool RequireStableSurface = true;
 
         [SerializeField] private bool _doInheritParentRotation = true;
-        [FormerlySerializedAs("_rotateTowardsSurfaceNormal")] [SerializeField] private bool _alignToProjectionVector = true;
-        [FormerlySerializedAs("_alignToProjectionVector")] [SerializeField] private bool _alignToSurfaceNormal = true;
+        [ShowIf("@this._projectionBehavior != SpawnPointProjectionBehavior.None")] [SerializeField] private bool _alignToProjectionVector = true;
+        [ShowIf("@this._projectionBehavior != SpawnPointProjectionBehavior.None")] [SerializeField] private bool _alignToSurfaceNormal = false;
         [SerializeField] private Vector3 _rotationEulerOffset = Vector3.zero;
         
         [ShowInInspector, ReadOnly] private Vector3? _projectedPosition = null; 

--- a/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
+++ b/Assets/Scripts/CaveV2/SpawnObjects/SpawnPoint.cs
@@ -45,6 +45,7 @@ namespace BML.Scripts.CaveV2.SpawnObjects
         [ShowIf("@this._projectionBehavior != SpawnPointProjectionBehavior.None")] [SerializeField] private bool _alignToProjectionVector = true;
         [ShowIf("@this._projectionBehavior != SpawnPointProjectionBehavior.None")] [SerializeField] private bool _alignToSurfaceNormal = false;
         [SerializeField] private Vector3 _rotationEulerOffset = Vector3.zero;
+        [SerializeField, MinMaxSlider(-180f, 180f)] private Vector2 _randomRotationRangeAroundUpAxis;
         
         [ShowInInspector, ReadOnly] private Vector3? _projectedPosition = null; 
         [ShowInInspector, ReadOnly] private Quaternion? _projectedRotation = null; 
@@ -198,6 +199,9 @@ namespace BML.Scripts.CaveV2.SpawnObjects
             var baseRotation = (_doInheritParentRotation
                 ? parentNode?.GameObject?.transform.rotation ?? Quaternion.identity
                 : Quaternion.identity);
+
+            var randomRotationDegrees = Random.Range(_randomRotationRangeAroundUpAxis.x, _randomRotationRangeAroundUpAxis.y);
+            var randomRotation = Quaternion.AngleAxis(randomRotationDegrees, Vector3.up);
             
             Vector3 projectDirection;
             Quaternion rotationOffset = Quaternion.Euler(_rotationEulerOffset);
@@ -206,7 +210,7 @@ namespace BML.Scripts.CaveV2.SpawnObjects
                 default:
                 case SpawnPointProjectionBehavior.None:
                     _projectedPosition = this.transform.position + (Vector3.up * spawnPosOffset);
-                    _projectedRotation = baseRotation * rotationOffset;
+                    _projectedRotation = baseRotation * randomRotation * rotationOffset;
                     return (_projectedPosition, _projectedRotation);
                 case SpawnPointProjectionBehavior.Gravity:
                     projectDirection = Vector3.down;
@@ -261,6 +265,7 @@ namespace BML.Scripts.CaveV2.SpawnObjects
                     _projectedRotation = baseRotation;
                 }
                 _projectedRotation *= rotationOffset;
+                _projectedRotation *= randomRotation;
                 return (_projectedPosition, _projectedRotation);
             }
 

--- a/Assets/Scripts/Explosive.cs
+++ b/Assets/Scripts/Explosive.cs
@@ -94,6 +94,7 @@ namespace BML.Scripts
                 Vector3 originToTarget = col.bounds.center - origin;
                 if (Physics.Raycast(origin, originToTarget.normalized, out hit, originToTarget.magnitude, _obstacleMask))
                 {
+                    Debug.Log($"Trying to hit {col.name} but hit {hit.collider.name} instead");
                     // Continue if hit obstacle
                     continue;
                 }

--- a/Assets/Scripts/Explosive.cs
+++ b/Assets/Scripts/Explosive.cs
@@ -10,7 +10,6 @@ namespace BML.Scripts
 {
     public class Explosive : MonoBehaviour
     {
-        
         [SerializeField] private bool _setOriginTransform;
         [SerializeField, ShowIf("_setOriginTransform")] private Transform _origin;
         [SerializeField] private FloatReference _explosionTime;
@@ -33,6 +32,9 @@ namespace BML.Scripts
         private bool isDeActivated;
         private float activateTime;
         private float currentFuseTime;
+
+        private const float _ExplosionRaycastDistanceThreshold = 0.9f;
+        private const float _ExplosionRaycastDistanceThresholdSquared = _ExplosionRaycastDistanceThreshold * _ExplosionRaycastDistanceThreshold;
 
         public void Activate()
         {
@@ -94,9 +96,13 @@ namespace BML.Scripts
                 Vector3 originToTarget = col.bounds.center - origin;
                 if (Physics.Raycast(origin, originToTarget.normalized, out hit, originToTarget.magnitude, _obstacleMask))
                 {
-                    Debug.Log($"Trying to hit {col.name} but hit {hit.collider.name} instead");
-                    // Continue if hit obstacle
-                    continue;
+                    bool withinThreshold = (hit.point - col.bounds.center).sqrMagnitude <= _ExplosionRaycastDistanceThresholdSquared;
+                    if (!withinThreshold)
+                    {
+                        // Continue if hit obstacle
+                        Debug.Log($"Trying to hit {col.name} but hit {hit.collider.name} instead");
+                        continue;
+                    }
                 }
 
                 Damageable damageable = col.GetComponent<Damageable>();

--- a/Assets/Scripts/Health/Health.cs
+++ b/Assets/Scripts/Health/Health.cs
@@ -65,6 +65,8 @@ namespace BML.Scripts
 
         public int StartingHealth => startingHealth;
 
+        public int MaxHealth => _hasMaxHealth ? _maxHealthReference.Value : 999;
+
         #endregion
         
         #region Unity Lifecycle
@@ -132,7 +134,7 @@ namespace BML.Scripts
         
         public int SetHealth(int newValue, HitInfo hitInfo = null)
         {
-            newValue = Mathf.Clamp(newValue, 0, _hasMaxHealth ? _maxHealthReference.Value : 999);
+            newValue = Mathf.Clamp(newValue, 0, MaxHealth);
 
             var oldValue = Value;
             _value = newValue;
@@ -156,9 +158,10 @@ namespace BML.Scripts
 
         public void Revive()
         {
-            _onHealthChange?.Invoke(Value, startingHealth);
-            OnHealthChange?.Invoke(Value, startingHealth);
-            _value = startingHealth;
+            var reviveHealth = (_hasMaxHealth ? MaxHealth : startingHealth);
+            _onHealthChange?.Invoke(Value, reviveHealth);
+            OnHealthChange?.Invoke(Value, reviveHealth);
+            _value = reviveHealth;
             _onRevive.Invoke();
             OnRevive?.Invoke();
         }

--- a/Assets/Scripts/Ore/OreShaderController.cs
+++ b/Assets/Scripts/Ore/OreShaderController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Sirenix.OdinInspector;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace BML.Scripts
 {
@@ -11,12 +12,15 @@ namespace BML.Scripts
 
         [SerializeField, Required] private Health _health;
         [SerializeField, Required] private Transform _critMarkerTransform;
-        [SerializeField, Required] private Renderer _renderer;
+        [FormerlySerializedAs("_renderer")] [SerializeField, Required] private Renderer _oreRenderer;
+        [SerializeField, Required] private Renderer _oreCrystalsRenderer;
         
         private static readonly int CritPosition = Shader.PropertyToID("_CritPosition");
         private static readonly int CrackPosition0 = Shader.PropertyToID("_CrackPosition0");
         private static readonly int CrackPosition1 = Shader.PropertyToID("_CrackPosition1");
         private static readonly int CrackPosition2 = Shader.PropertyToID("_CrackPosition2");
+        
+        private static readonly int DamageFac = Shader.PropertyToID("_DamageFac");
 
         #endregion
 
@@ -27,32 +31,14 @@ namespace BML.Scripts
             
         }
 
-        private void OnEnable()
-        {
-            // UpdateShader();
-            // _health.OnHealthChange += UpdateShaderOnHealthChange;
-        }
-        
-        private void OnDisable()
-        {
-            // _health.OnHealthChange -= UpdateShaderOnHealthChange;
-        }
-
         #endregion
-
-        private void UpdateShaderOnHealthChange(int prevHealth, int currHealth)
-        {
-            float healthFactor = (float) currHealth / _health.StartingHealth;
-            // _renderer.material.SetFloat("_VertexCrackStrengthFactor", 1 - healthFactor);
-            // _renderer.material.SetFloat("_CrackStrengthFactor", 1 - healthFactor);
-        }
 
         public void UpdateShaderOnPickaxeInteract(HitInfo hitInfo)
         {
             if (_critMarkerTransform.gameObject.activeInHierarchy)
             {
-                var localCritPosition = _renderer.transform.InverseTransformPoint(_critMarkerTransform.position);
-                _renderer.material.SetVector(CritPosition, localCritPosition);
+                var localCritPosition = _oreRenderer.transform.InverseTransformPoint(_critMarkerTransform.position);
+                _oreRenderer.material.SetVector(CritPosition, localCritPosition);
             }
 
             float oreDamageFac = 1 - ((float)_health.Value / (float)_health.StartingHealth);
@@ -64,37 +50,32 @@ namespace BML.Scripts
                 case 0:
                     break;
                 case 1:
-                    var crackPosition0 = _renderer.material.GetVector(CrackPosition0);
+                    var crackPosition0 = _oreRenderer.material.GetVector(CrackPosition0);
                     if (crackPosition0 == Vector4.zero)
                     {
-                        var localHitPosition = _renderer.transform.InverseTransformPoint(hitInfo.HitPositon);
-                        _renderer.material.SetVector(CrackPosition0, localHitPosition);
+                        var localHitPosition = _oreRenderer.transform.InverseTransformPoint(hitInfo.HitPositon);
+                        _oreRenderer.material.SetVector(CrackPosition0, localHitPosition);
                     }
                     break;
                 case 2:
-                    var crackPosition1 = _renderer.material.GetVector(CrackPosition1);
+                    var crackPosition1 = _oreRenderer.material.GetVector(CrackPosition1);
                     if (crackPosition1 == Vector4.zero)
                     {
-                        var localHitPosition = _renderer.transform.InverseTransformPoint(hitInfo.HitPositon);
-                        _renderer.material.SetVector(CrackPosition1, localHitPosition);
+                        var localHitPosition = _oreRenderer.transform.InverseTransformPoint(hitInfo.HitPositon);
+                        _oreRenderer.material.SetVector(CrackPosition1, localHitPosition);
                     }
                     break;
                 case 3:
-                    var crackPosition2 = _renderer.material.GetVector(CrackPosition2);
+                    var crackPosition2 = _oreRenderer.material.GetVector(CrackPosition2);
                     if (crackPosition2 == Vector4.zero)
                     {
-                        var localHitPosition = _renderer.transform.InverseTransformPoint(hitInfo.HitPositon);
-                        _renderer.material.SetVector(CrackPosition2, localHitPosition);
+                        var localHitPosition = _oreRenderer.transform.InverseTransformPoint(hitInfo.HitPositon);
+                        _oreRenderer.material.SetVector(CrackPosition2, localHitPosition);
                     }
                     break;
             }
-        }
-
-        private void UpdateShader()
-        { 
-            float healthFactor = (float) _health.Value / _health.StartingHealth;
-            // _renderer.material.SetFloat("_VertexCrackStrengthFactor", 1 - healthFactor);
-            // _renderer.material.SetFloat("_CrackStrengthFactor", 1 - healthFactor);
+            
+            _oreCrystalsRenderer.material.SetFloat(DamageFac, oreDamageFac);
         }
 
     }

--- a/Assets/Scripts/Ore/OreShaderController.cs
+++ b/Assets/Scripts/Ore/OreShaderController.cs
@@ -49,8 +49,11 @@ namespace BML.Scripts
 
         public void UpdateShaderOnPickaxeInteract(HitInfo hitInfo)
         {
-            var localCritPosition = _critMarkerTransform.position - _renderer.transform.position;
-            _renderer.material.SetVector(CritPosition, localCritPosition);
+            if (_critMarkerTransform.gameObject.activeInHierarchy)
+            {
+                var localCritPosition = _renderer.transform.InverseTransformPoint(_critMarkerTransform.position);
+                _renderer.material.SetVector(CritPosition, localCritPosition);
+            }
 
             float oreDamageFac = 1 - ((float)_health.Value / (float)_health.StartingHealth);
             const int numCracks = 3;
@@ -64,7 +67,7 @@ namespace BML.Scripts
                     var crackPosition0 = _renderer.material.GetVector(CrackPosition0);
                     if (crackPosition0 == Vector4.zero)
                     {
-                        var localHitPosition = hitInfo.HitPositon - _renderer.transform.position;
+                        var localHitPosition = _renderer.transform.InverseTransformPoint(hitInfo.HitPositon);
                         _renderer.material.SetVector(CrackPosition0, localHitPosition);
                     }
                     break;
@@ -72,7 +75,7 @@ namespace BML.Scripts
                     var crackPosition1 = _renderer.material.GetVector(CrackPosition1);
                     if (crackPosition1 == Vector4.zero)
                     {
-                        var localHitPosition = hitInfo.HitPositon - _renderer.transform.position;
+                        var localHitPosition = _renderer.transform.InverseTransformPoint(hitInfo.HitPositon);
                         _renderer.material.SetVector(CrackPosition1, localHitPosition);
                     }
                     break;
@@ -80,7 +83,7 @@ namespace BML.Scripts
                     var crackPosition2 = _renderer.material.GetVector(CrackPosition2);
                     if (crackPosition2 == Vector4.zero)
                     {
-                        var localHitPosition = hitInfo.HitPositon - _renderer.transform.position;
+                        var localHitPosition = _renderer.transform.InverseTransformPoint(hitInfo.HitPositon);
                         _renderer.material.SetVector(CrackPosition2, localHitPosition);
                     }
                     break;

--- a/Assets/Scripts/Ore/OreShaderController.cs
+++ b/Assets/Scripts/Ore/OreShaderController.cs
@@ -10,7 +10,13 @@ namespace BML.Scripts
         #region Inspector
 
         [SerializeField, Required] private Health _health;
+        [SerializeField, Required] private Transform _critMarkerTransform;
         [SerializeField, Required] private Renderer _renderer;
+        
+        private static readonly int CritPosition = Shader.PropertyToID("_CritPosition");
+        private static readonly int CrackPosition0 = Shader.PropertyToID("_CrackPosition0");
+        private static readonly int CrackPosition1 = Shader.PropertyToID("_CrackPosition1");
+        private static readonly int CrackPosition2 = Shader.PropertyToID("_CrackPosition2");
 
         #endregion
 
@@ -24,12 +30,12 @@ namespace BML.Scripts
         private void OnEnable()
         {
             // UpdateShader();
-            _health.OnHealthChange += UpdateShaderOnHealthChange;
+            // _health.OnHealthChange += UpdateShaderOnHealthChange;
         }
         
         private void OnDisable()
         {
-            _health.OnHealthChange -= UpdateShaderOnHealthChange;
+            // _health.OnHealthChange -= UpdateShaderOnHealthChange;
         }
 
         #endregion
@@ -37,15 +43,55 @@ namespace BML.Scripts
         private void UpdateShaderOnHealthChange(int prevHealth, int currHealth)
         {
             float healthFactor = (float) currHealth / _health.StartingHealth;
-            _renderer.material.SetFloat("_VertexCrackStrengthFactor", 1 - healthFactor);
-            _renderer.material.SetFloat("_CrackStrengthFactor", 1 - healthFactor);
+            // _renderer.material.SetFloat("_VertexCrackStrengthFactor", 1 - healthFactor);
+            // _renderer.material.SetFloat("_CrackStrengthFactor", 1 - healthFactor);
+        }
+
+        public void UpdateShaderOnPickaxeInteract(HitInfo hitInfo)
+        {
+            var localCritPosition = _critMarkerTransform.position - _renderer.transform.position;
+            _renderer.material.SetVector(CritPosition, localCritPosition);
+
+            float oreDamageFac = 1 - ((float)_health.Value / (float)_health.StartingHealth);
+            const int numCracks = 3;
+            int oreDamageStep = Mathf.CeilToInt(oreDamageFac * numCracks);
+            switch (oreDamageStep)
+            {
+                default:
+                case 0:
+                    break;
+                case 1:
+                    var crackPosition0 = _renderer.material.GetVector(CrackPosition0);
+                    if (crackPosition0 == Vector4.zero)
+                    {
+                        var localHitPosition = hitInfo.HitPositon - _renderer.transform.position;
+                        _renderer.material.SetVector(CrackPosition0, localHitPosition);
+                    }
+                    break;
+                case 2:
+                    var crackPosition1 = _renderer.material.GetVector(CrackPosition1);
+                    if (crackPosition1 == Vector4.zero)
+                    {
+                        var localHitPosition = hitInfo.HitPositon - _renderer.transform.position;
+                        _renderer.material.SetVector(CrackPosition1, localHitPosition);
+                    }
+                    break;
+                case 3:
+                    var crackPosition2 = _renderer.material.GetVector(CrackPosition2);
+                    if (crackPosition2 == Vector4.zero)
+                    {
+                        var localHitPosition = hitInfo.HitPositon - _renderer.transform.position;
+                        _renderer.material.SetVector(CrackPosition2, localHitPosition);
+                    }
+                    break;
+            }
         }
 
         private void UpdateShader()
         { 
             float healthFactor = (float) _health.Value / _health.StartingHealth;
-            _renderer.material.SetFloat("_VertexCrackStrengthFactor", 1 - healthFactor);
-            _renderer.material.SetFloat("_CrackStrengthFactor", 1 - healthFactor);
+            // _renderer.material.SetFloat("_VertexCrackStrengthFactor", 1 - healthFactor);
+            // _renderer.material.SetFloat("_CrackStrengthFactor", 1 - healthFactor);
         }
 
     }

--- a/Assets/Scripts/Utils/SpawnObjectsUtil.cs
+++ b/Assets/Scripts/Utils/SpawnObjectsUtil.cs
@@ -4,15 +4,17 @@ namespace BML.Scripts.Utils
 {
     public static class SpawnObjectsUtil
     {
-        public static bool GetPointTowards(Vector3 position, Vector3 direction, out Vector3 result, LayerMask layerMask, float checkDistance)
+        public static bool GetPointTowards(Vector3 position, Vector3 direction, out Vector3 hitPoint, out Vector3 hitNormal, LayerMask layerMask, float checkDistance)
         {
             var didHit = Physics.Raycast(new Ray(position, direction), out var hitInfo, checkDistance, layerMask);
             if (didHit)
             {
-                result = hitInfo.point;
+                hitPoint = hitInfo.point;
+                hitNormal = hitInfo.normal;
                 return true;
             }
-            result = position;
+            hitPoint = position;
+            hitNormal = hitInfo.normal;
             return false;
         }
     }


### PR DESCRIPTION
* Add new ore model (made in Blender) and new ore damage shader. 
* Randomize rotation of spawned ore. Seed ore shader random from rotation.
* Adjust rock color to blend with walls.
* Scale mimic to fit new ore better.
* Expose MaxHealth on Health component.
* Add SpawnPoint option to align to hit surface normal. Move 'Require Stable Surface' param to SpawnPoint. Require stable surface for ore and align to surface normal.
* Add slight threshold to explosive raycast, intended to allow for objects (ore) slightly embedded in the wall.

---------
Co-authored-by: Dan C <djc5627@gmail.com>